### PR TITLE
41 add runge kutta 4 for population propagation

### DIFF
--- a/src/calc_2DES.c
+++ b/src/calc_2DES.c
@@ -208,13 +208,14 @@ void calc_2DES(t_non* non, int parentRank, int parentSize, int subRank, int subS
                     exit(1);
                 }
 
-                if (non->propagation == 1) {
+		propagate_vector(non, Hamil_i_e, leftnr[t1], leftni[t1], 1, 1,1);
+                /*if (non->propagation == 1) {
                     propagate_vec_coupling_S(
                         non, Hamil_i_e, leftnr[t1], leftni[t1], non->ts, 1
                     );
                 } else if (non->propagation == 0) {
                     propagate_vec_DIA_S(non, Hamil_i_e, leftnr[t1], leftni[t1], 1);
-                }
+                }*/
 
             }
         }
@@ -274,8 +275,9 @@ void calc_2DES(t_non* non, int parentRank, int parentSize, int subRank, int subS
             }
 
             /* Propagate */
-            if (non->propagation == 1) propagate_vec_coupling_S(non, Hamil_i_e, mut3r, mut3i, non->ts, 1);
-            if (non->propagation == 0) propagate_vec_DIA_S(non, Hamil_i_e, mut3r, mut3i, 1);
+	    propagate_vector(non, Hamil_i_e, mut3r, mut3i, 1,1,1);
+            /*if (non->propagation == 1) propagate_vec_coupling_S(non, Hamil_i_e, mut3r, mut3i, non->ts, 1);
+            if (non->propagation == 0) propagate_vec_DIA_S(non, Hamil_i_e, mut3r, mut3i, 1);*/
         }
 
         /* Stimulated emission (SE) */
@@ -402,15 +404,17 @@ void calc_2DES(t_non* non, int parentRank, int parentSize, int subRank, int subS
             }
 
             /* Propagate left side rephasing */
-            if (non->propagation == 1) {
+	    propagate_vector(non, Hamil_i_e, leftrr, leftri, 1,1, 1);
+            /*if (non->propagation == 1) {
                 propagate_vec_coupling_S(non, Hamil_i_e, leftrr, leftri, non->ts, 1);
             } else if (non->propagation == 0) {
                 propagate_vec_DIA_S(non, Hamil_i_e, leftrr, leftri, 1);
-            }
+            }*/
 
             /* Propagate left side nonrephasing */
             for (int t1 = 0; t1 < non->tmax1; t1++) {
-                if (non->propagation == 0) {
+		propagate_vector(non, Hamil_i_e, leftnr[t1], leftni[t1], 1,1,1);
+                /* if (non->propagation == 0) {
                     propagate_vec_DIA_S(
                         non, Hamil_i_e, leftnr[t1], leftni[t1], 1
                     );
@@ -418,7 +422,7 @@ void calc_2DES(t_non* non, int parentRank, int parentSize, int subRank, int subS
                     propagate_vec_coupling_S(
                         non, Hamil_i_e, leftnr[t1], leftni[t1], non->ts, 1
                     );
-                }
+                }*/
             }
         }
 
@@ -550,6 +554,34 @@ void calc_2DES(t_non* non, int parentRank, int parentSize, int subRank, int subS
 
                     for (t1 = 0; t1 < non->tmax1; t1++) {
                         propagate_vec_coupling_S(
+                            non, Hamil_i_e, rightrr[t1], rightri[t1], non->ts, -1
+                        );
+                    }
+                }
+		else if(non->propagation == 1) {
+                    // Key parallel loop 1
+                    // Initial step
+                    propagate_vec_RK4_doubles_ES(
+                        non, Hamil_i_e, fr, fi, non->ts);
+
+                    int t1;
+                    #pragma omp parallel for \
+                        shared(non,Hamil_i_e,ft1r,ft1i) \
+                        schedule(static, 1)
+
+                    for (t1 = 0; t1 < non->tmax1; t1++) {
+                        propagate_vec_RK4_doubles_ES(
+                            non, Hamil_i_e, ft1r[t1], ft1i[t1], non->ts);
+                    }
+
+                    // Key parallel loop 2
+                    // Initial step
+                    propagate_vec_RK4(
+                        non, Hamil_i_e, rightnr, rightni, non->ts, -1
+                    );
+
+                    for (t1 = 0; t1 < non->tmax1; t1++) {
+                        propagate_vec_RK4(
                             non, Hamil_i_e, rightrr[t1], rightri[t1], non->ts, -1
                         );
                     }

--- a/src/calc_2DIR.c
+++ b/src/calc_2DIR.c
@@ -225,13 +225,15 @@ void calc_2DIR(t_non* non, int parentRank, int parentSize, int subRank, int subS
                     exit(1);
                 }
 
+                propagate_vector(non, Hamil_i_e, leftnr[t1], leftni[t1], 1,1,1);
+		/*
                 if (non->propagation == 1) {
                     propagate_vec_coupling_S(
                         non, Hamil_i_e, leftnr[t1], leftni[t1], non->ts, 1
                     );
                 } else if (non->propagation == 0) {
                     propagate_vec_DIA_S(non, Hamil_i_e, leftnr[t1], leftni[t1], 1);
-                }
+                }*/
 
             }
         }
@@ -291,8 +293,9 @@ void calc_2DIR(t_non* non, int parentRank, int parentSize, int subRank, int subS
             }
 
             /* Propagate */
-            if (non->propagation == 1) propagate_vec_coupling_S(non, Hamil_i_e, mut3r, mut3i, non->ts, 1);
-            if (non->propagation == 0) propagate_vec_DIA_S(non, Hamil_i_e, mut3r, mut3i, 1);
+	    propagate_vector(non, Hamil_i_e, mut3r, mut3i, 1,1,1);
+/*            if (non->propagation == 1) propagate_vec_coupling_S(non, Hamil_i_e, mut3r, mut3i, non->ts, 1);
+            if (non->propagation == 0) propagate_vec_DIA_S(non, Hamil_i_e, mut3r, mut3i, 1);*/
         }
 
         /* Stimulated emission (SE) */
@@ -417,15 +420,17 @@ void calc_2DIR(t_non* non, int parentRank, int parentSize, int subRank, int subS
             }
 
             /* Propagate left side rephasing */
-            if (non->propagation == 1) {
+	    propagate_vector(non, Hamil_i_e, leftrr, leftri, 1,1,1);
+/*            if (non->propagation == 1) {
                 propagate_vec_coupling_S(non, Hamil_i_e, leftrr, leftri, non->ts, 1);
             } else if (non->propagation == 0) {
                 propagate_vec_DIA_S(non, Hamil_i_e, leftrr, leftri, 1);
-            }
+            }*/
 
             /* Propagate left side nonrephasing */
             for (int t1 = 0; t1 < non->tmax1; t1++) {
-                if (non->propagation == 0) {
+		propagate_vector(non, Hamil_i_e, leftnr[t1], leftni[t1], 1,1,1);
+/*                if (non->propagation == 0) {
                     propagate_vec_DIA_S(
                         non, Hamil_i_e, leftnr[t1], leftni[t1], 1
                     );
@@ -433,7 +438,7 @@ void calc_2DIR(t_non* non, int parentRank, int parentSize, int subRank, int subS
                     propagate_vec_coupling_S(
                         non, Hamil_i_e, leftnr[t1], leftni[t1], non->ts, 1
                     );
-                }
+                }*/
             }
         }
 

--- a/src/calc_2DIR.c
+++ b/src/calc_2DIR.c
@@ -571,6 +571,35 @@ void calc_2DIR(t_non* non, int parentRank, int parentSize, int subRank, int subS
                         );
                     }
                 }
+		/* RK4 propagation */
+		else if(non->propagation == 3) {
+                    // Key parallel loop 1
+                    // Initial step
+                    propagate_vec_RK4_doubles(
+                        non, Hamil_i_e, fr, fi, non->ts,Anh);
+
+                    int t1;
+                    #pragma omp parallel for \
+                        shared(non,Hamil_i_e,Anh,ft1r,ft1i) \
+                        schedule(static, 1)
+
+                    for (t1 = 0; t1 < non->tmax1; t1++) {
+                        propagate_vec_RK4_doubles(
+                            non, Hamil_i_e, ft1r[t1], ft1i[t1], non->ts,Anh);
+                    }
+
+                    // Key parallel loop 2
+                    // Initial step
+                    propagate_vec_RK4(
+                        non, Hamil_i_e, rightnr, rightni, non->ts, -1
+                    );
+
+                    for (t1 = 0; t1 < non->tmax1; t1++) {
+                        propagate_vec_RK4(
+                            non, Hamil_i_e, rightrr[t1], rightri[t1], non->ts, -1
+                        );
+                    }
+                }
             }
         }
 

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -307,7 +307,7 @@ void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m
     /* We assume the Hamiltonian to be time independent! */
 
     /* Find k1 */
-    for (k=0;k<=kmax;k++){
+    for (k=0;k<kmax;k++){
        k1r[col[k]]+=H0[k]*ci[row[k]];
        k1i[col[k]]-=H0[k]*cr[row[k]];
        if (row[k]!=col[k]){
@@ -316,7 +316,7 @@ void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m
        }
     }
     /* Find k2 */
-    for (k=0;k<=kmax;k++){
+    for (k=0;k<kmax;k++){
        k2r[col[k]]+=H0[k]*(ci[row[k]]+k1i[row[k]]*0.5);
        k2i[col[k]]-=H0[k]*(cr[row[k]]+k1r[row[k]]*0.5);
        if (row[k]!=col[k]){
@@ -325,7 +325,7 @@ void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m
        }
     }
     /* Find k3 */
-    for (k=0;k<=kmax;k++){
+    for (k=0;k<kmax;k++){
        k3r[col[k]]+=H0[k]*(ci[row[k]]+k2i[row[k]]*0.5);
        k3i[col[k]]-=H0[k]*(cr[row[k]]+k2r[row[k]]*0.5);
        if (row[k]!=col[k]){
@@ -334,7 +334,7 @@ void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m
        }
     }
     /* Find k4 */
-    for (k=0;k<=kmax;k++){
+    for (k=0;k<kmax;k++){
        k4r[col[k]]+=H0[k]*(ci[row[k]]+k3i[row[k]]);
        k4i[col[k]]-=H0[k]*(cr[row[k]]+k3r[row[k]]);
        if (row[k]!=col[k]){

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -577,6 +577,9 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
         }
 
     }
+    free(HD),free(H0),free(col),free(row);
+    free(k1r),free(k2r),free(k3r),free(k4r);
+    free(k1i),free(k2i),free(k3i),free(k4i);
     return;
 }
 

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -383,7 +383,7 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
     int index1,index2;
     float J;
     float cr1, cr2, ci1, ci2;
-    int i, k, kmax;
+    int i,j, k, kmax;
     int N2;
 
     /* printf("Entered the RK4 routine.\n"); */
@@ -452,9 +452,9 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
 
     /* Find k1 */
     /* Diagonal part */
-        for (i=0;i<N2;i++){
-            k1r[i]+=HD[i]*ci[i];
-            k1i[i]-=HD[i]*cr[i];
+        for (k=0;k<N2;k++){
+            k1r[k]+=HD[k]*ci[k];
+            k1i[k]-=HD[k]*cr[k];
         }
     /* Loop over couplings */
 	for (k=0;k<kmax;k++){
@@ -465,7 +465,7 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
             for (c=0; c < N; c++) {
                 index1 = Sindex(a,c,N);
                 index2 = Sindex(b,c,N);
-		factor = 1;
+		factor = 1.0;
                     /* c < a,b */
 		    /* c == a */
 		if (c==a) factor=sqrt2;
@@ -482,9 +482,9 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
 	
     /* Find k2 */
     /* Diagonal part */
-        for (i=0;i<N2;i++){
-            k2r[i]+=HD[i]*(ci[i]+k1i[i]*0.5);
-            k2i[i]-=HD[i]*(cr[i]+k1r[i]*0.5);
+        for (k=0;k<N2;k++){
+            k2r[k]+=HD[k]*(ci[k]+k1i[k]*0.5);
+            k2i[k]-=HD[k]*(cr[k]+k1r[k]*0.5);
         }
     /* Loop over couplings */
         for (k=0;k<kmax;k++){
@@ -495,7 +495,7 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
             for (c=0; c < N; c++) {
                 index1 = Sindex(a,c,N);
                 index2 = Sindex(b,c,N);
-                factor = 1;
+                factor = 1.0;
                     /* c < a,b */
                     /* c == a */
                 if (c==a) factor=sqrt2;
@@ -512,9 +512,9 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
 
     /* Find k3 */
     /* Diagonal part */
-        for (i=0;i<N2;i++){
-            k3r[i]+=HD[i]*(ci[i]+k2i[i]*0.5);
-            k3i[i]-=HD[i]*(cr[i]+k2r[i]*0.5);
+        for (k=0;k<N2;k++){
+            k3r[k]+=HD[k]*(ci[k]+k2i[k]*0.5);
+            k3i[k]-=HD[k]*(cr[k]+k2r[k]*0.5);
         }
     /* Loop over couplings */
         for (k=0;k<kmax;k++){
@@ -525,7 +525,7 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
             for (c=0; c < N; c++) {
                 index1 = Sindex(a,c,N);
                 index2 = Sindex(b,c,N);
-                factor = 1;
+                factor = 1.0;
                     /* c < a,b */
                     /* c == a */
                 if (c==a) factor=sqrt2;
@@ -542,9 +542,9 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
 
     /* Find k4 */
     /* Diagonal part */
-        for (i=0;i<N2;i++){
-            k4r[i]+=HD[i]*(ci[i]+k3i[i]);
-            k4i[i]-=HD[i]*(cr[i]+k3r[i]);
+        for (k=0;k<N2;k++){
+            k4r[k]+=HD[k]*(ci[k]+k3i[k]);
+            k4i[k]-=HD[k]*(cr[k]+k3r[k]);
         }
     /* Loop over couplings */
         for (k=0;k<kmax;k++){
@@ -555,7 +555,7 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
             for (c=0; c < N; c++) {
                 index1 = Sindex(a,c,N);
                 index2 = Sindex(b,c,N);
-                factor = 1;
+                factor = 1.0;
                     /* c < a,b */
                     /* c == a */
                 if (c==a) factor=sqrt2;
@@ -572,8 +572,8 @@ void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *
 
     /* Update wavefunction */
 	for (k=0;k<N2;k++){
-            cr[k]=cr[k]+(k1r[k]+2*k2r[k]+2*k3r[k]+k4r[k])/6.0;
-            ci[k]=ci[k]+(k1i[k]+2*k2i[k]+2*k3i[k]+k4i[k])/6.0;
+            cr[k]=cr[k]+(k1r[k]+2.0*k2r[k]+2.0*k3r[k]+k4r[k])/6.0;
+            ci[k]=ci[k]+(k1i[k]+2.0*k2i[k]+2.0*k3i[k]+k4i[k])/6.0;
         }
 
     }

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -257,7 +257,7 @@ int propagate_vec_DIA_S(t_non* non, float* Hamiltonian_i, float* cr, float* ci, 
     return elements;
 }
 
-/* Propagate using the Runge Kutta 4 algorithm */
+/* Propagate singles using the Runge Kutta 4 algorithm */
 void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign){
     float f;
     int index, N;
@@ -368,6 +368,59 @@ void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m
     return;
 
 }
+
+/* Propagate singles using the Runge Kutta 4 algorithm */
+void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign,float *Anh){
+    float f;
+    int index, N;
+    float *H0;
+    float *k1r,*k2r,*k3r,*k4r;
+    float *k1i,*k2i,*k3i,*k4i;
+    int *col, *row;
+    float *ocr, *oci;
+    int a, b, c;
+    float J;
+    float cr1, cr2, ci1, ci2;
+    int i, k, kmax;
+    int N2;
+
+    /* printf("Entered the RK4 routine.\n"); */
+
+    N = non->singles;
+    N2=(N*(N+1))/2;
+    f = non->deltat * icm2ifs * twoPi * sign / m;
+    H0 = (float *)malloc(N2*sizeof(float));
+    col = (int *)malloc(N2*sizeof(int));
+    row = (int *)malloc(N2*sizeof(int));
+    k1r = (float *)calloc(N,sizeof(float));
+    k1i = (float *)calloc(N,sizeof(float));
+    k2r = (float *)calloc(N,sizeof(float));
+    k2i = (float *)calloc(N,sizeof(float));
+    k3r = (float *)calloc(N,sizeof(float));
+    k3i = (float *)calloc(N,sizeof(float));
+    k4r = (float *)calloc(N,sizeof(float));
+    k4i = (float *)calloc(N,sizeof(float));
+
+    /* Build sparse Hamiltonians H0 */
+    k = 0;
+    for (a = 0; a < N; a++) {
+        for (b = a; b < N; b++) {
+            index = Sindex(a, b, N);
+            if (fabs(Hamiltonian_i[index]) > non->couplingcut || a==b) {
+                index = Sindex(a, b, N);
+                H0[k] = f* Hamiltonian_i[index];
+                col[k] = a, row[k] = b;
+                k++;
+            }
+        }
+    }
+    kmax = k;
+
+
+    printf("Not implemented yet!\n");
+    exit(0);
+}
+
 
 /* Propagate using diagonal vs. coupling sparce algorithm */
 void propagate_vec_coupling_S(t_non* non, float* Hamiltonian_i, float* cr, float* ci, int m, int sign) {

--- a/src/propagate.h
+++ b/src/propagate.h
@@ -8,7 +8,7 @@ void propagate_vec_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int s
 void propagate_t2_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,float **vr,float **vi,int sign);
 int propagate_vec_DIA_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int sign);
 void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
-void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign,float *Anh);
+void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,float *Anh);
 void propagate_vec_coupling_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
 void propagate_vec_coupling_S_doubles(t_non *non,float *Hamiltonian_i,float *cr,float
 *ci,int m,float *Anh);

--- a/src/propagate.h
+++ b/src/propagate.h
@@ -8,6 +8,7 @@ void propagate_vec_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int s
 void propagate_t2_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,float **vr,float **vi,int sign);
 int propagate_vec_DIA_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int sign);
 void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
+void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign,float *Anh);
 void propagate_vec_coupling_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
 void propagate_vec_coupling_S_doubles(t_non *non,float *Hamiltonian_i,float *cr,float
 *ci,int m,float *Anh);

--- a/src/propagate.h
+++ b/src/propagate.h
@@ -7,6 +7,7 @@ void propagate_matrix(t_non *non,float * Hamil_i_e,float *vecr,float *veci,int s
 void propagate_vec_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int sign);
 void propagate_t2_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,float **vr,float **vi,int sign);
 int propagate_vec_DIA_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int sign);
+void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
 void propagate_vec_coupling_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
 void propagate_vec_coupling_S_doubles(t_non *non,float *Hamiltonian_i,float *cr,float
 *ci,int m,float *Anh);

--- a/src/propagate.h
+++ b/src/propagate.h
@@ -9,6 +9,7 @@ void propagate_t2_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,float 
 int propagate_vec_DIA_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int sign);
 void propagate_vec_RK4(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
 void propagate_vec_RK4_doubles(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,float *Anh);
+void propagate_vec_RK4_doubles_ES(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m);
 void propagate_vec_coupling_S(t_non *non,float *Hamiltonian_i,float *cr,float *ci,int m,int sign);
 void propagate_vec_coupling_S_doubles(t_non *non,float *Hamiltonian_i,float *cr,float
 *ci,int m,float *Anh);

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -216,7 +216,7 @@ void readInput(int argc, char* argv[], t_non* non) {
     if (!strcmp(prop, "Coupling")) {
         non->propagation = 1;
         printf("\nUsing propagation scheme 'Coupling'!\n");
-        printf("Coupling cutoff %f effective during t1 and t3.\n\n",
+        printf("Coupling cutoff %f effective during t1, t2, and t3.\n\n",
                non->couplingcut);
     }
     if (!strcmp(prop, "Diagonal")) {
@@ -224,6 +224,12 @@ void readInput(int argc, char* argv[], t_non* non) {
         printf("\nUsing propagation with full diagonalization!\n\n");
         printf(RED "Presently NOT implemented. Use sparse with no cutoff!\n" RESET);
         exit(0);
+    }
+    if (!strcmp(prop, "RK4")) {
+        non->propagation = 3;
+        printf("\nUsing propagation scheme 'RK4' with coupling cut!\n");
+        printf("Coupling cutoff %f effective during t1, t2, and t3.\n\n",
+               non->couplingcut);
     }
 
     if (non->propagation == 0) {


### PR DESCRIPTION
Added Runge Kutta 4 for propagation (Propagate RK4). The method is as for Coupling available for all linear methods and for the coherence times of 2D spectroscopies. The implementation also allows for using the Couplingcut to speed up calculations by throwing away couplings below the cutoff. The RK4 seems to be slightly slower than Coupling, but it converges a bit faster so the Trotter setting for dividing timesteps into smaller pieces (also availble for RK4) may not be needed or larger timesteps can be used.