### PR TITLE
128 make propagation with instantaneous shift

### DIFF
--- a/src/propagate.c
+++ b/src/propagate.c
@@ -150,6 +150,14 @@ void propagate_t2_DIA(t_non *non,float *Hamiltonian_i,float *cr,float *ci,float 
         }
     }
 
+    /* --- Mean-field Stokes shift adjustment on diagonal --- */
+    if (non->useStokesShift && non->stokesLambda) {
+        for (a = 0; a < N; a++) {
+            float pop_a = cr[a]*cr[a] + ci[a]*ci[a];
+            H[a + N * a] -= non->stokesLambda[a] * pop_a; /* cm^-1 */
+        }
+    }
+
     diagonalizeLPD(H, e, N);
     /* Exponentiate [U=exp(-i/h H dt)] */
     for (a = 0; a < N; a++) {
@@ -857,6 +865,15 @@ void propagate_vec_coupling_S(t_non* non, float* Hamiltonian_i, float* cr, float
             }
         }
     }
+
+    /* --- Mean-field Stokes shift (population-dependent) --- */
+    if (non->useStokesShift && non->stokesLambda) {
+        for (a = 0; a < N; a++) {
+            float pop_a = cr[a]*cr[a] + ci[a]*ci[a];
+            H0[a] -= non->stokesLambda[a] * pop_a; /* cm^-1 */
+        }
+    }
+
     kmax = k;
 
     /* Exponentiate diagonal [U=exp(-i/2h H0 dt)] */

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -84,6 +84,13 @@ void propagate_vec_DIA(t_non* non, float* Hamiltonian_i, float* cr, float* ci, i
         }
     }
 
+    if (non->useStokesShift && non->stokesLambda) {
+        for (a = 0; a < N; a++) {
+            float pop_a = cr[a]*cr[a] + ci[a]*ci[a];
+            H[a + N * a] -= non->stokesLambda[a] * pop_a;  /* cm^-1 */
+        }
+    }
+
     diagonalizeLPD(H, e, N);
     /* Exponentiate [U=exp(-i/h H dt)] */
     for (a = 0; a < N; a++) {

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -212,15 +212,25 @@ int propagate_vec_DIA_S(t_non* non, float* Hamiltonian_i, float* cr, float* ci, 
     crr = (float *)calloc(N2, sizeof(float));
     cri = (float *)calloc(N2, sizeof(float));
 
-    /* Build Hamiltonian */
+        /* Build Hamiltonian */
     for (a = 0; a < N; a++) {
-        H[a + N * a] = Hamiltonian_i[a + N * a - (a * (a + 1)) / 2]; /* Diagonal*/
+        H[a + N * a] = Hamiltonian_i[a + N * a - (a * (a + 1)) / 2]; /* Diagonal */
         for (b = a + 1; b < N; b++) {
             H[a + N * b] = Hamiltonian_i[b + N * a - (a * (a + 1)) / 2];
             H[b + N * a] = Hamiltonian_i[b + N * a - (a * (a + 1)) / 2];
         }
     }
+
+    /* --- Mean-field Stokes shift (for Pop + Sparse) --- */
+    if (non->useStokesShift && non->stokesLambda) {
+        for (a = 0; a < N; a++) {
+            float pop_a = cr[a]*cr[a] + ci[a]*ci[a];
+            H[a + N * a] -= non->stokesLambda[a] * pop_a;  /* cm^-1 */
+        }
+    }
+
     diagonalizeLPD(H, e, N);
+    
     /* Exponentiate [U=exp(-i/h H dt)] */
     for (a = 0; a < N; a++) {
         re_U[a] = cos(e[a] * f);

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -245,14 +245,9 @@ void readInput(int argc, char* argv[], t_non* non) {
                 exit(1);
             }
 
-            for (int i = 0; i < N; i++) {
-                float s = non->stokesSigma[i];
-                non->stokesLambda[i] = (s * s) / (2.0f * K_B_CM_PER_K * non->temperature);
-            }
+            
 
-            printf("StokesShift enabled. Computed lambda_i (cm^-1):");
-            for (int i = 0; i < N; ++i) printf(" %.2f", non->stokesLambda[i]);
-            printf("\n");
+            
 
             continue;
         }
@@ -262,6 +257,20 @@ void readInput(int argc, char* argv[], t_non* non) {
     }
     while (1 == 1);
     fclose(inputFile);
+
+        /* Make StokesSigma independent of line order: recompute lambda with final T */
+    if (non->useStokesShift && non->stokesSigma && non->stokesLambda) {
+        const float K_B_CM_PER_K = 0.6950348f;
+        if (non->temperature <= 0.0f) {
+            fprintf(stderr, "Error: Temperature must be > 0 when using StokesSigma.\n");
+            exit(1);
+        }
+        for (int i = 0; i < non->singles; ++i) {
+            float s = non->stokesSigma[i];
+            non->stokesLambda[i] = (s * s) / (2.0f * K_B_CM_PER_K * non->temperature);
+        }
+    }
+
 
     non->dt1 = 1, non->dt2 = 1, non->dt3 = 1;
     // Set length of linear response function

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -197,7 +197,7 @@ void readInput(int argc, char* argv[], t_non* non) {
         if (keyWordI("PrintLevel", Buffer, &non->printLevel, LabelLength) == 1) continue;
 
                 /* --- StokesSigma: 1 or N floats (cm^-1). Enables Stokes shift. --- */
-        if (strncmp(Buffer, "StokesSigma", LabelLength) == 0 && LabelLength == strlen("StokesSigma")) {
+        if (keyWordI("Doubles", Buffer, &non->doubles, LabelLength) == 1) continue;
             non->useStokesShift = 1;
 
             int N = non->singles;

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -197,7 +197,7 @@ void readInput(int argc, char* argv[], t_non* non) {
         if (keyWordI("PrintLevel", Buffer, &non->printLevel, LabelLength) == 1) continue;
 
                 /* --- StokesSigma: 1 or N floats (cm^-1). Enables Stokes shift. --- */
-        if (keyWordI("Doubles", Buffer, &non->doubles, LabelLength) == 1) continue;
+        if (strncmp(Buffer, "StokesSigma", LabelLength) == 0 && LabelLength == strlen("StokesSigma")) {
             non->useStokesShift = 1;
 
             int N = non->singles;
@@ -244,6 +244,7 @@ void readInput(int argc, char* argv[], t_non* non) {
                 fprintf(stderr, "Error: Temperature must be > 0 when using StokesSigma.\n");
                 exit(1);
             }
+
             for (int i = 0; i < N; i++) {
                 float s = non->stokesSigma[i];
                 non->stokesLambda[i] = (s * s) / (2.0f * K_B_CM_PER_K * non->temperature);
@@ -255,6 +256,7 @@ void readInput(int argc, char* argv[], t_non* non) {
 
             continue;
         }
+
 
 
     }

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -39,6 +39,9 @@ void readInput(int argc, char* argv[], t_non* non) {
     non->homogen=0.0;
     non->inhomogen=0.0;
     non->window=0; // No windowing by default
+    non->useStokesShift = 0;
+    non->stokesSigma    = NULL;
+    non->stokesLambda   = NULL;
     sprintf(non->basis, "Local");
     sprintf(non->hamiltonian, "Full");
     sprintf(non->pbcFName, "");
@@ -192,6 +195,66 @@ void readInput(int argc, char* argv[], t_non* non) {
 
         // Read double excited states
         if (keyWordI("PrintLevel", Buffer, &non->printLevel, LabelLength) == 1) continue;
+
+                /* --- StokesSigma: 1 or N floats (cm^-1). Enables Stokes shift. --- */
+        if (strncmp(Buffer, "StokesSigma", LabelLength) == 0 && LabelLength == strlen("StokesSigma")) {
+            non->useStokesShift = 1;
+
+            int N = non->singles;
+            if (N <= 0) {
+                fprintf(stderr, "Error: 'StokesSigma' must appear after 'Singles' is defined.\n");
+                exit(1);
+            }
+
+            /* Allocate arrays */
+            non->stokesSigma  = (float*)calloc(N, sizeof(float));
+            non->stokesLambda = (float*)calloc(N, sizeof(float));
+
+            /* Start tokenizing from after the label */
+            char *rest = Buffer + LabelLength;
+            while (*rest == ' ' || *rest == '\t') rest++;
+            char *p = strtok(rest, " \t\r\n");
+
+            /* Read values */
+            int cnt = 0;
+            float vals[2048];
+            while (p && cnt < 2048) {
+                vals[cnt++] = (float)atof(p);
+                p = strtok(NULL, " \t\r\n");
+            }
+
+            if (cnt == 0) {
+                fprintf(stderr, "Error: StokesSigma given with no values.\n");
+                exit(1);
+            }
+
+            /* Broadcast or per-site */
+            if (cnt == 1) {
+                for (int i = 0; i < N; i++) non->stokesSigma[i] = vals[0];
+            } else if (cnt == N) {
+                for (int i = 0; i < N; i++) non->stokesSigma[i] = vals[i];
+            } else {
+                fprintf(stderr, "Error: StokesSigma count (%d) must be 1 or Singles (%d).\n", cnt, N);
+                exit(1);
+            }
+
+            /* Compute lambda_i = sigma_i^2 / (2 K_B T) */
+            const float K_B_CM_PER_K = 0.6950348f;
+            if (non->temperature <= 0.0f) {
+                fprintf(stderr, "Error: Temperature must be > 0 when using StokesSigma.\n");
+                exit(1);
+            }
+            for (int i = 0; i < N; i++) {
+                float s = non->stokesSigma[i];
+                non->stokesLambda[i] = (s * s) / (2.0f * K_B_CM_PER_K * non->temperature);
+            }
+
+            printf("StokesShift enabled. Computed lambda_i (cm^-1):");
+            for (int i = 0; i < N; ++i) printf(" %.2f", non->stokesLambda[i]);
+            printf("\n");
+
+            continue;
+        }
 
 
     }

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -245,6 +245,10 @@ void readInput(int argc, char* argv[], t_non* non) {
                 exit(1);
             }
 
+            printf("DEBUG: StokesSigma has been enabled. First sigma = %f, count = %d\n",
+            non->stokesSigma[0], cnt);
+
+
             
 
             

--- a/src/types.h
+++ b/src/types.h
@@ -84,6 +84,9 @@ typedef struct {
   int window; // 0 no window, 1 Hann window
   int *psites;
   int printLevel;
+  int useStokesShift;   /* 0=off (default), 1=on */
+  float *stokesSigma;     /* [singles], cm^-1 */
+  float *stokesLambda;    /* [singles], cm^-1 (computed from sigma, T) */
 } t_non;
 
 #define RESET   "\033[0m"


### PR DESCRIPTION
Modified the NISE program to include a Stokes shift by applying an instantaneous λ (reorganization energy) adjustment during Hamiltonian propagation.

When using StokesSigma, ensure the keyword is written exactly as StokesSigma followed by either one value (applied to all sites) or N values (one per site), separated by spaces or tabs on the same line. Always define Singles and Temperature somewhere in the input file (in any order). Do not repeat the StokesSigma line, leave it blank, or exceed the number of sites. Max number of sites is 2048.