### PR TITLE
148 as a user it would be nice to be able to set how much data nise outputs so i can perform and store more runs

### DIFF
--- a/src/1DFFT.c
+++ b/src/1DFFT.c
@@ -148,6 +148,7 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
   fftw_complex *fftIn,*fftOut;
   fftw_plan fftPlan;
   float *spec_r,*spec_i;
+  float freq;
   /* Integers */
   int i,fft;
   int pro_dim,ip;
@@ -205,25 +206,55 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
           spec_i[i+fft*2*ip]=fftOut[i][0]*2*non->deltat*c_v;
      }
   }
-  outone=fopen(fname,"w");
-  for (i=fft/2;i<=fft-1;i++){
-    if (-((fft-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((fft-i)/non->deltat/c_v/fft-shift1)<non->max1){
-//      fprintf(outone,"%f %e %e\n",-((fft-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
-      fprintf(outone,"%f ",-((fft-i)/non->deltat/c_v/fft-shift1));
-      for (ip=0;ip<pro_dim;ip++){
-         fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+
+  // For normal setting save as text file
+  if (strcmp(non->outputformat, "Normal") == 0) {
+    outone=fopen(fname,"w");
+    for (i=fft/2;i<=fft-1;i++){
+      if (-((fft-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((fft-i)/non->deltat/c_v/fft-shift1)<non->max1){
+//        fprintf(outone,"%f %e %e\n",-((fft-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
+        fprintf(outone,"%f ",-((fft-i)/non->deltat/c_v/fft-shift1));
+        for (ip=0;ip<pro_dim;ip++){
+          fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+        }
+        fprintf(outone,"\n");
       }
-      fprintf(outone,"\n");
+    }
+    for (i=0;i<=fft/2-1;i++){
+      if (-((-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((-i)/non->deltat/c_v/fft-shift1)<non->max1){
+//        fprintf(outone,"%f %e %e\n",-((-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
+        fprintf(outone,"%f ",-((-i)/non->deltat/c_v/fft-shift1));
+        for (ip=0;ip<pro_dim;ip++){
+          fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+        }
+        fprintf(outone,"\n");
+      }
     }
   }
-  for (i=0;i<=fft/2-1;i++){
-    if (-((-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((-i)/non->deltat/c_v/fft-shift1)<non->max1){
-//      fprintf(outone,"%f %e %e\n",-((-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
-      fprintf(outone,"%f ",-((-i)/non->deltat/c_v/fft-shift1));
-      for (ip=0;ip<pro_dim;ip++){
-          fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+
+  // For absorption setting save as binary file
+  if (strcmp_nocase(non->outputformat, "Binary") == 0) {
+    char *binary_fname = replace_ext(fname, ".dat", ".bin");
+    outone=fopen(binary_fname,"wb");
+    for (i=fft/2;i<=fft-1;i++){
+      if (-((fft-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((fft-i)/non->deltat/c_v/fft-shift1)<non->max1){
+        freq=-((fft-i)/non->deltat/c_v/fft-shift1);
+        fwrite(&freq, sizeof(float), 1, outone);
+        for (ip=0;ip<pro_dim;ip++){
+          fwrite(&spec_r[i+fft*2*ip], sizeof(float), 1, outone);
+          fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
+        }
       }
-      fprintf(outone,"\n");
+    }
+    for (i=0;i<=fft/2-1;i++){
+      if (-((-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((-i)/non->deltat/c_v/fft-shift1)<non->max1){
+        freq=-((-i)/non->deltat/c_v/fft-shift1);
+        fwrite(&freq, sizeof(float), 1, outone);
+        for (ip=0;ip<pro_dim;ip++){
+          fwrite(&spec_r[i+fft*2*ip], sizeof(float), 1, outone);
+          fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
+        }
+      }
     }
   }
 

--- a/src/1DFFT.c
+++ b/src/1DFFT.c
@@ -212,12 +212,12 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
     outone=fopen(fname,"w");
     for (i=fft/2;i<=fft-1;i++){
       if (-((fft-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((fft-i)/non->deltat/c_v/fft-shift1)<non->max1){
-//        fprintf(outone,"%f %e %e\n",-((fft-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
         fprintf(outone,"%f ",-((fft-i)/non->deltat/c_v/fft-shift1));
         for (ip=0;ip<pro_dim;ip++){
+          // For Normal Format write both real (absorptive) and imaginary (dispersive) components
           if (strcmp_nocase(non->outputformat,"Normal") ==0){
             fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
-          } else {
+          } else { // For Compact Format only write absorptive component
             fprintf(outone,"%e ",spec_r[i+fft*2*ip]);
           }
         }
@@ -226,12 +226,12 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
     }
     for (i=0;i<=fft/2-1;i++){
       if (-((-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((-i)/non->deltat/c_v/fft-shift1)<non->max1){
-//        fprintf(outone,"%f %e %e\n",-((-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
         fprintf(outone,"%f ",-((-i)/non->deltat/c_v/fft-shift1));
         for (ip=0;ip<pro_dim;ip++){
+          // For Normal Format write both real (absorptive) and imaginary (dispersive) components
           if (strcmp_nocase(non->outputformat,"Normal") ==0){
             fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
-          } else {
+          } else { // For Compact Format only write absorptive component
             fprintf(outone,"%e ",spec_r[i+fft*2*ip]);
           }
         }
@@ -249,7 +249,9 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
         freq=-((fft-i)/non->deltat/c_v/fft-shift1);
         fwrite(&freq, sizeof(float), 1, outone);
         for (ip=0;ip<pro_dim;ip++){
+          // For both Binary Formats write both real (absorptive) components
           fwrite(&spec_r[i+fft*2*ip], sizeof(float), 1, outone);
+          // For Binary Format (not BinaryCompact) write imaginary (dispersive) components
           if (strcmp_nocase(non->outputformat,"Binary")==0){
             fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
           }
@@ -261,7 +263,9 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
         freq=-((-i)/non->deltat/c_v/fft-shift1);
         fwrite(&freq, sizeof(float), 1, outone);
         for (ip=0;ip<pro_dim;ip++){
+          // For both Binary Formats write both real (absorptive) components
           fwrite(&spec_r[i+fft*2*ip], sizeof(float), 1, outone);
+          // For Binary Format (not BinaryCompact) write imaginary (dispersive) components
           if (strcmp_nocase(non->outputformat,"Binary")==0){
             fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
           }

--- a/src/1DFFT.c
+++ b/src/1DFFT.c
@@ -207,7 +207,7 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
      }
   }
 
-  // For normal setting save as text file
+  // For normal and compact setting save as text file
   if (string_in_array(non->outputformat,(char*[]){"Normal","Compact"},2)){
     outone=fopen(fname,"w");
     for (i=fft/2;i<=fft-1;i++){
@@ -240,7 +240,7 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
     }
   }
 
-  // For absorption setting save as binary file
+  // For output format setting save as binary or binary compact file
   if (string_in_array(non->outputformat,(char*[]){"Binary","CompactBinary"},2)){
     char *binary_fname = replace_ext(fname, ".dat", ".bin");
     outone=fopen(binary_fname,"wb");

--- a/src/1DFFT.c
+++ b/src/1DFFT.c
@@ -208,14 +208,18 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
   }
 
   // For normal setting save as text file
-  if (strcmp(non->outputformat, "Normal") == 0) {
+  if (string_in_array(non->outputformat,(char*[]){"Normal","Compact"},2)){
     outone=fopen(fname,"w");
     for (i=fft/2;i<=fft-1;i++){
       if (-((fft-i)/non->deltat/c_v/fft-shift1)>non->min1 && -((fft-i)/non->deltat/c_v/fft-shift1)<non->max1){
 //        fprintf(outone,"%f %e %e\n",-((fft-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
         fprintf(outone,"%f ",-((fft-i)/non->deltat/c_v/fft-shift1));
         for (ip=0;ip<pro_dim;ip++){
-          fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+          if (strcmp_nocase(non->outputformat,"Normal") ==0){
+            fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+          } else {
+            fprintf(outone,"%e ",spec_r[i+fft*2*ip]);
+          }
         }
         fprintf(outone,"\n");
       }
@@ -225,7 +229,11 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
 //        fprintf(outone,"%f %e %e\n",-((-i)/non->deltat/c_v/fft-shift1),fftOut[i][1],fftOut[i][0]);
         fprintf(outone,"%f ",-((-i)/non->deltat/c_v/fft-shift1));
         for (ip=0;ip<pro_dim;ip++){
-          fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+          if (strcmp_nocase(non->outputformat,"Normal") ==0){
+            fprintf(outone,"%e %e ",spec_r[i+fft*2*ip],spec_i[i+fft*2*ip]);
+          } else {
+            fprintf(outone,"%e ",spec_r[i+fft*2*ip]);
+          }
         }
         fprintf(outone,"\n");
       }
@@ -233,7 +241,7 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
   }
 
   // For absorption setting save as binary file
-  if (strcmp_nocase(non->outputformat, "Binary") == 0) {
+  if (string_in_array(non->outputformat,(char*[]){"Binary","CompactBinary"},2)){
     char *binary_fname = replace_ext(fname, ".dat", ".bin");
     outone=fopen(binary_fname,"wb");
     for (i=fft/2;i<=fft-1;i++){
@@ -242,7 +250,9 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
         fwrite(&freq, sizeof(float), 1, outone);
         for (ip=0;ip<pro_dim;ip++){
           fwrite(&spec_r[i+fft*2*ip], sizeof(float), 1, outone);
-          fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
+          if (strcmp_nocase(non->outputformat,"Binary")==0){
+            fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
+          }
         }
       }
     }
@@ -252,7 +262,9 @@ void do_1DFFT(t_non *non,char fname[],float *re_S_1,float *im_S_1,int samples){
         fwrite(&freq, sizeof(float), 1, outone);
         for (ip=0;ip<pro_dim;ip++){
           fwrite(&spec_r[i+fft*2*ip], sizeof(float), 1, outone);
-          fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
+          if (strcmp_nocase(non->outputformat,"Binary")==0){
+            fwrite(&spec_i[i+fft*2*ip], sizeof(float), 1, outone);
+          }
         }
       }
     }

--- a/src/NISE_subs.c
+++ b/src/NISE_subs.c
@@ -317,13 +317,14 @@ time_t log_time(time_t t0, FILE* log) {
 }
 
 /* Compare a string to an array of options */
+/* The comparizon is not case sensitive */
 int string_in_array(char* string_to_compare, char* string_array[], int array_size) {
     for (int i = 0; i < array_size; i++) {
-        if (!strcmp(string_to_compare, string_array[i])) {
+        if (!strcmp_nocase(string_to_compare, string_array[i])) {
             return i+1; // return the index of the matched string
 	    }
     }
-    return 0; // if no match is found, return -1
+    return 0; // if no match is found, return 0
 }
 
 /* Determine number of samples to use and write to log file */

--- a/src/NISE_subs.c
+++ b/src/NISE_subs.c
@@ -10,6 +10,7 @@
 #include "read_trajectory.h"
 #include "randomlib.h"
 #include "util/asprintf.h"
+#include <ctype.h>
 #include <cblas.h>
 
 // Subroutines for nonadiabatic code
@@ -910,4 +911,57 @@ void read_vector_from_file(char fname[],float *vector,int N){
         fscanf(file_handle,"%f",&vector[i]);
     }
     fclose(file_handle);
+}
+
+// Replace the extension of a filename if it matches the old extension, otherwise return NULL
+char *replace_ext(const char *filename,
+                  const char *old_ext,
+                  const char *new_ext)
+{
+    size_t len = strlen(filename);
+    size_t old_len = strlen(old_ext);
+    size_t new_len = strlen(new_ext);
+
+    if (len < old_len) return NULL;
+
+    // check if filename ends with old_ext
+    if (strcmp(filename + len - old_len, old_ext) != 0)
+        return NULL;
+
+    // allocate new string
+    size_t new_size = len - old_len + new_len + 1;
+    char *result = malloc(new_size);
+    if (!result) return NULL;
+
+    // copy base part
+    memcpy(result, filename, len - old_len);
+
+    // append new extension
+    memcpy(result + (len - old_len), new_ext, new_len);
+
+    // null terminate
+    result[new_size - 1] = '\0';
+
+    return result;
+}
+
+// Compare two strings ignoring case
+int strcmp_nocase(const char *s1, const char *s2)
+{
+    while (*s1 && *s2) {
+        unsigned char c1 = (unsigned char)*s1;
+        unsigned char c2 = (unsigned char)*s2;
+
+        c1 = (unsigned char)tolower(c1);
+        c2 = (unsigned char)tolower(c2);
+
+        if (c1 != c2)
+            return c1 - c2;
+
+        s1++;
+        s2++;
+    }
+
+    return (unsigned char)tolower((unsigned char)*s1)
+         - (unsigned char)tolower((unsigned char)*s2);
 }

--- a/src/NISE_subs.c
+++ b/src/NISE_subs.c
@@ -966,3 +966,41 @@ int strcmp_nocase(const char *s1, const char *s2)
     return (unsigned char)tolower((unsigned char)*s1)
          - (unsigned char)tolower((unsigned char)*s2);
 }
+
+/* Save linear response function to file */
+int save_time_domain_response(t_non *non,const char *filename,float *re_S_1,float *im_S_1,int pro_dim,int samples){
+    int ip, t1;
+    float time,re,im;
+    FILE *outone;
+    if (strcmp_nocase(non->outputformat, "Normal")==0) {
+        outone=fopen(filename,"w");
+        for (t1=0;t1<non->tmax1;t1+=non->dt1){
+            fprintf(outone,"%f ",t1*non->deltat);
+            for (ip=0;ip<pro_dim;ip++){
+                fprintf(outone,"%e %e ",re_S_1[t1+ip*non->tmax]/samples,im_S_1[t1+ip*non->tmax]/samples);
+            }
+            fprintf(outone,"\n");
+        }
+        fclose(outone);
+        return 0;
+    } else if (strcmp_nocase(non->outputformat, "Binary")==0) {
+        char *binary_fname = replace_ext(filename, ".dat", ".bin");
+        outone=fopen(binary_fname,"wb");
+        for (t1=0;t1<non->tmax1;t1+=non->dt1){
+            time=t1*non->deltat;
+            fwrite(&time,sizeof(float),1,outone);
+            for (ip=0;ip<pro_dim;ip++){
+                re=re_S_1[t1+ip*non->tmax]/samples;
+                im=im_S_1[t1+ip*non->tmax]/samples;
+                fwrite(&re,sizeof(float),1,outone);
+                fwrite(&im,sizeof(float),1,outone);
+            }
+        }
+        fclose(outone);
+        return 0;
+    } else {
+        printf("\n");
+        printf("To store response function use OutputFormat Normal or Binary.\n\n");
+    }
+    return 0;
+}

--- a/src/NISE_subs.h
+++ b/src/NISE_subs.h
@@ -59,6 +59,8 @@ char *replace_ext(const char *filename,
                   const char *old_ext,
                   const char *new_ext);
 int strcmp_nocase(const char *s1, const char *s2);
+int save_time_domain_response(t_non *non,const char *filename,float *re_S_1,
+    float *im_S_1,int prodim,int samples);
 
 // Index triangular matrix
 // Put in the .h file to allow external referencing

--- a/src/NISE_subs.h
+++ b/src/NISE_subs.h
@@ -55,7 +55,10 @@ void integrate_rate_response(float *rate_response,int T,float *is13,float *isimp
 void write_matrix_to_file(char fname[],float *matrix,int N);
 void read_vector_from_file(char fname[],float *vector,int N);
 void read_matrix_from_file(char fname[],float *matrix,int N);
-
+char *replace_ext(const char *filename,
+                  const char *old_ext,
+                  const char *new_ext);
+int strcmp_nocase(const char *s1, const char *s2);
 
 // Index triangular matrix
 // Put in the .h file to allow external referencing

--- a/src/absorption.c
+++ b/src/absorption.c
@@ -33,7 +33,7 @@ void absorption(t_non *non){
   /* File handles */
   FILE *H_traj,*mu_traj;
   FILE *C_traj;
-  FILE *outone,*log;
+  FILE *log;
   FILE *Cfile;
 
   /* Integers */
@@ -178,17 +178,7 @@ void absorption(t_non *non){
   fclose(mu_traj),fclose(H_traj);
 
   /* Save time domain response */
-  if (strcmp(non->outputformat, "Normal") == 0) {
-    outone=fopen("TD_Absorption.dat","w");
-    for (t1=0;t1<non->tmax1;t1+=non->dt1){
-      fprintf(outone,"%f ",t1*non->deltat);
-      for (ip=0;ip<pro_dim;ip++){
-        fprintf(outone,"%e %e ",re_S_1[t1+ip*non->tmax]/samples,im_S_1[t1+ip*non->tmax]/samples);
-      }
-      fprintf(outone,"\n");
-    }
-    fclose(outone);
-  }
+  save_time_domain_response(non,"TD_Absorption.dat",re_S_1,im_S_1,pro_dim,samples);
   
   /* Do Forier transform and save */
   do_1DFFT(non,"Absorption.dat",re_S_1,im_S_1,samples);

--- a/src/absorption.c
+++ b/src/absorption.c
@@ -178,16 +178,18 @@ void absorption(t_non *non){
   fclose(mu_traj),fclose(H_traj);
 
   /* Save time domain response */
-  outone=fopen("TD_Absorption.dat","w");
-  for (t1=0;t1<non->tmax1;t1+=non->dt1){
-    fprintf(outone,"%f ",t1*non->deltat);
-    for (ip=0;ip<pro_dim;ip++){
-      fprintf(outone,"%e %e ",re_S_1[t1+ip*non->tmax]/samples,im_S_1[t1+ip*non->tmax]/samples);
+  if (strcmp(non->outputformat, "Normal") == 0) {
+    outone=fopen("TD_Absorption.dat","w");
+    for (t1=0;t1<non->tmax1;t1+=non->dt1){
+      fprintf(outone,"%f ",t1*non->deltat);
+      for (ip=0;ip<pro_dim;ip++){
+        fprintf(outone,"%e %e ",re_S_1[t1+ip*non->tmax]/samples,im_S_1[t1+ip*non->tmax]/samples);
+      }
+      fprintf(outone,"\n");
     }
-    fprintf(outone,"\n");
+    fclose(outone);
   }
-  fclose(outone);
-
+  
   /* Do Forier transform and save */
   do_1DFFT(non,"Absorption.dat",re_S_1,im_S_1,samples);
 

--- a/src/calc_CD.c
+++ b/src/calc_CD.c
@@ -34,7 +34,7 @@ void calc_CD(t_non *non){
   /* File handles */
   FILE *H_traj,*mu_traj,*pos_traj;
   FILE *C_traj;
-  FILE *outone,*log;
+  FILE *log;
   FILE *Cfile;
 
   /* Integers */
@@ -334,16 +334,8 @@ void calc_CD(t_non *non){
     fclose(Cfile);
   }
 
-  outone=fopen("TD_CD.dat","w");
-  for (t1=0;t1<non->tmax1;t1+=non->dt1){
-/*    fprintf(outone,"%f %e %e\n",t1*non->deltat,re_S_1[t1]/samples,im_S_1[t1]/samples); */
-      fprintf(outone,"%f ",t1*non->deltat);
-      for (ip=0;ip<pro_dim;ip++){
-         fprintf(outone,"%e %e ",re_S_1[t1+ip*non->tmax]/samples,im_S_1[t1+ip*non->tmax]/samples);
-      }
-      fprintf(outone,"\n");
-  }
-  fclose(outone);
+  // Save response function
+  save_time_domain_response(non,"TD_CD.dat",re_S_1,im_S_1,pro_dim,samples);
 
   /* Do Forier transform and save */
   do_1DFFT(non,"CD.dat",re_S_1,im_S_1,samples);

--- a/src/calc_LD.c
+++ b/src/calc_LD.c
@@ -32,7 +32,7 @@ void LD(t_non *non){
   /* File handles */
   FILE *H_traj,*mu_traj;
   FILE *C_traj;
-  FILE *outone,*log;
+  FILE *log;
   FILE *Cfile;
 
   /* Integers */
@@ -238,16 +238,7 @@ void LD(t_non *non){
   }
 
   /* Save time domain response */
-  outone=fopen("TD_LD.dat","w");
-  for (t1=0;t1<non->tmax1;t1+=non->dt1){
-    /* fprintf(outone,"%f %e %e\n",t1*non->deltat,re_S_1[t1]/samples,im_S_1[t1]/samples); */
-      fprintf(outone,"%f ",t1*non->deltat);
-      for (ip=0;ip<pro_dim;ip++){
-         fprintf(outone,"%e %e ",re_S_1[t1+ip*non->tmax]/samples,im_S_1[t1+ip*non->tmax]/samples);
-      }
-      fprintf(outone,"\n");
-  }
-  fclose(outone);
+  save_time_domain_response(non,"TD_LD.dat",re_S_1,im_S_1,pro_dim,samples);
 
   /* Do Forier transform and save */
   do_1DFFT(non,"LD.dat",re_S_1,im_S_1,samples);

--- a/src/raman.c
+++ b/src/raman.c
@@ -31,7 +31,7 @@ void raman(t_non *non){
   /* File handles */
   FILE *H_traj,*alpha_traj;
   FILE *C_traj;
-  FILE *outone,*log;
+  FILE *log;
   FILE *Cfile;
 
   /* Integers */
@@ -245,27 +245,9 @@ void raman(t_non *non){
   }
 
   /* Save time domain response */
-  outone=fopen("TD_Raman_VV.dat","w");
-  for (t1=0;t1<non->tmax1;t1+=non->dt1){
-    //fprintf(outone,"%f %e %e\n",t1*non->deltat,VV_re_S_1[t1]/samples,VV_im_S_1[t1]/samples);
-     fprintf(outone,"%f ",t1*non->deltat);
-     for (ip=0;ip<pro_dim;ip++){
-        fprintf(outone,"%e %e ",VV_re_S_1[t1+ip*non->tmax]/samples,VV_im_S_1[t1+ip*non->tmax]/samples);
-     }
-     fprintf(outone,"\n");
-  }
-  fclose(outone);
+  save_time_domain_response(non,"TD_Raman_VV.dat",VV_re_S_1,VV_im_S_1,pro_dim,samples);
 
-    outone=fopen("TD_Raman_VH.dat","w");
-  for (t1=0;t1<non->tmax1;t1+=non->dt1){
-    //fprintf(outone,"%f %e %e\n",t1*non->deltat,2*VH_re_S_1[t1]/samples,2*VH_im_S_1[t1]/samples);
-     fprintf(outone,"%f ",t1*non->deltat);
-     for (ip=0;ip<pro_dim;ip++){
-        fprintf(outone,"%e %e ",VH_re_S_1[t1+ip*non->tmax]/samples,VH_im_S_1[t1+ip*non->tmax]/samples);
-     }
-     fprintf(outone,"\n");
-  }
-  fclose(outone);
+  save_time_domain_response(non,"TD_Raman_VH.dat",VH_re_S_1,VH_im_S_1,pro_dim,samples);
 
   /* Do Forier transform and save */
   do_1DFFT(non,"Raman_VV.dat",VV_re_S_1,VV_im_S_1,samples);

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -43,6 +43,7 @@ void readInput(int argc, char* argv[], t_non* non) {
     sprintf(non->basis, "Local");
     sprintf(non->hamiltonian, "Full");
     sprintf(non->pbcFName, "");
+    sprintf(non->outputformat, "Normal");
 
     if (argc < 2) {
         printf(RED "Specify input file name on command line!\n");
@@ -99,6 +100,9 @@ void readInput(int argc, char* argv[], t_non* non) {
 
         // PBC file keyword
         if (keyWordS("PBCfile", Buffer, non->pbcFName, LabelLength) == 1) continue;
+
+        // Output format keyword
+        if (keyWordS("Outputformat", Buffer, non->outputformat, LabelLength) == 1) continue;
 
         // SingleShift file keyword
         if (keyWordS("SingleShiftfile", Buffer, non->singleShiftFName, LabelLength) == 1) continue;

--- a/src/sfg.c
+++ b/src/sfg.c
@@ -40,7 +40,7 @@ void sfg(t_non *non){
   /* File handles */
   FILE *H_traj,*alpha_traj,*mu_traj;
   FILE *C_traj;
-  FILE *outone,*log;
+  FILE *log;
   FILE *Cfile;
 
   /* Integers */
@@ -242,27 +242,9 @@ void sfg(t_non *non){
   }
 
   /* Save time domain response */
-  outone=fopen("TD_SFG_PPP.dat","w");
-  for (t1=0;t1<non->tmax1;t1+=non->dt1){
-    //fprintf(outone,"%f %e %e\n",t1*non->deltat,VV_re_S_1[t1]/samples,VV_im_S_1[t1]/samples);
-     fprintf(outone,"%f ",t1*non->deltat);
-     for (ip=0;ip<pro_dim;ip++){
-        fprintf(outone,"%e %e ",PPP_re_S_1[t1+ip*non->tmax]/samples,PPP_im_S_1[t1+ip*non->tmax]/samples);
-     }
-     fprintf(outone,"\n");
-  }
-  fclose(outone);
+  save_time_domain_response(non,"TD_SFG_PPP.dat",PPP_re_S_1,PPP_im_S_1,pro_dim,samples);
 
-  outone=fopen("TD_SFG_SSP.dat","w");
-  for (t1=0;t1<non->tmax1;t1+=non->dt1){
-    //fprintf(outone,"%f %e %e\n",t1*non->deltat,2*VH_re_S_1[t1]/samples,2*VH_im_S_1[t1]/samples);
-     fprintf(outone,"%f ",t1*non->deltat);
-     for (ip=0;ip<pro_dim;ip++){
-        fprintf(outone,"%e %e ",SSP_re_S_1[t1+ip*non->tmax]/samples,SSP_im_S_1[t1+ip*non->tmax]/samples);
-     }
-     fprintf(outone,"\n");
-  }
-  fclose(outone);
+  save_time_domain_response(non,"TD_SFG_SSP.dat",SSP_re_S_1,SSP_im_S_1,pro_dim,samples);
 
   /* Do Forier transform and save */
   do_1DFFT(non,"SFG_PPP.dat",PPP_re_S_1,PPP_im_S_1,samples);

--- a/src/types.h
+++ b/src/types.h
@@ -67,6 +67,7 @@ typedef struct {
   char technique[256];
   char basis[256];
   char pdbFName[256];
+  char outputformat[256];
   char hamiltonian[256];
   char couplingFName[256];
   char pbcFName[256];

--- a/src/types_MPI.c
+++ b/src/types_MPI.c
@@ -8,7 +8,7 @@
 // The T_NON_TYPE variable is declared as const to prevent modification and ensure that it is only initialized once.
 
 const t_non_datatype T_NON_TYPE = {
-    69,
+    70,
     {
         1, 1, 1,
         1, 1, 1,
@@ -25,7 +25,7 @@ const t_non_datatype T_NON_TYPE = {
         256, 256, 256, 256,
         256, 256, 256, 256,
         256, 256, 256, 256,
-        256,
+        256, 256,
         1,
         1,
         1, 1,
@@ -55,7 +55,7 @@ const t_non_datatype T_NON_TYPE = {
         MPI_CHAR, MPI_CHAR, MPI_CHAR, MPI_CHAR,
         MPI_CHAR, MPI_CHAR, MPI_CHAR, MPI_CHAR,
         MPI_CHAR, MPI_CHAR, MPI_CHAR, MPI_CHAR,
-        MPI_CHAR,
+        MPI_CHAR, MPI_CHAR,
         MPI_INT,
         MPI_INT,
         MPI_FLOAT, MPI_FLOAT,
@@ -85,7 +85,7 @@ const t_non_datatype T_NON_TYPE = {
         offsetof(t_non, energyFName), offsetof(t_non, dipoleFName), offsetof(t_non, alphaFName),offsetof(t_non, positionFName),
         offsetof(t_non, anharFName), offsetof(t_non, overdipFName), offsetof(t_non, singleShiftFName), offsetof(t_non, technique),
         offsetof(t_non, pdbFName), offsetof(t_non, basis), offsetof(t_non, hamiltonian), offsetof(t_non, couplingFName),
-        offsetof(t_non, pbcFName),
+        offsetof(t_non, pbcFName), offsetof(t_non, outputformat),
         offsetof(t_non, tmax),
         offsetof(t_non, cluster),
         offsetof(t_non, shifte), offsetof(t_non, shiftf),

--- a/src/types_MPI.h
+++ b/src/types_MPI.h
@@ -13,7 +13,7 @@
     MPI_Aint offsets[LEN];\
 }
 
-typedef CUSTOM_MPI_DATATYPE(69) t_non_datatype;
+typedef CUSTOM_MPI_DATATYPE(70) t_non_datatype;
 extern const t_non_datatype T_NON_TYPE;
 
 #endif


### PR DESCRIPTION
For issue #148 the new keyword "Outputformat" was added taking the options:
"Binary", "Normal", "Compact" and "CompactBinary". The options should work as described in the
issue. There examples of how to read and plot the binary formats in python are also given. The format
is formally not different from the text one exept the data are stored as float32.

The options works for all linear response with the exception of DOS and luminescence, where the projections
are handled differently. 

Note that the program is not sensitive to the case for "Binary", "Normal", "Compact" and "CompactBinary". This will be made more generally applicable to other options and keywords in a future issue.