### PR TITLE
150 speedup of mcfret density with blas

### DIFF
--- a/src/mcfret.c
+++ b/src/mcfret.c
@@ -1420,68 +1420,142 @@ void average_density_matrix(float *ave_den_mat,t_non *non){
     return;
 }
 
-/* Matrix multiplication for different segments */
+// /* Matrix multiplication for different segments */
+// void segment_matrix_mul(float *rA,float *iA,float *rB,float *iB,
+//     float *rC,float *iC,int *psites,int segments,int si,int sk,int sj,int N){
+//     int i,j,k;
+//     /* Set initial values of results matrix to zero to be sure */
+//     clearvec(rC,N*N);
+//     clearvec(iC,N*N);
+
+//     int Npsj, Npsk;
+//     int cj, ck;
+//     Npsj=0;
+//     Npsk=0;
+
+//     float *psj, *psk;
+//     psj=(float *)calloc(N,sizeof(float));
+//     psk=(float *)calloc(N,sizeof(float));
+
+//     for (i=0;i<N;i++){
+//         if (psites[i]==sj){
+//             psj[Npsj]=i;
+//             Npsj++;
+//         }
+//         if (psites[i]==sk){
+//             psk[Npsk]=i;
+//             Npsk++;
+//         }
+//     }
+
+// #pragma omp parallel for
+//     for (i=0;i<N;i++){
+//         if (psites[i]==si){
+//             for (cj=0;cj<Npsj;cj++){
+//                 j=psj[cj];
+//                 for (ck=0;ck<Npsk;ck++){
+//                     k=psk[ck];
+//                     rC[i*N+j]+=rA[i*N+k]*rB[k*N+j]-iA[i*N+k]*iB[k*N+j];
+//                     iC[i*N+j]+=rA[i*N+k]*iB[k*N+j]+iA[i*N+k]*rB[k*N+j];
+//                 }
+//             }
+//         }
+//     }
+
+//     /*
+//     for (i=0;i<N;i++){
+//         if (psites[i]==si){
+//             for (j=0;j<N;j++){
+//                 if (psites[j]==sj){
+//                     for (k=0;k<N;k++){
+//                         if (psites[k]==sk){
+//                             rC[i*N+j]+=rA[i*N+k]*rB[k*N+j]-iA[i*N+k]*iB[k*N+j];
+//                             iC[i*N+j]+=rA[i*N+k]*iB[k*N+j]+iA[i*N+k]*rB[k*N+j];
+//                         } 
+//                     } 
+//                 }
+//             }
+//         }
+//     }
+//     */
+//     free(psj);
+//     free(psk);
+//     return;
+// } 
+
+/*  Faster BLAS based matrix multiplication */
 void segment_matrix_mul(float *rA,float *iA,float *rB,float *iB,
     float *rC,float *iC,int *psites,int segments,int si,int sk,int sj,int N){
+
     int i,j,k;
-    /* Set initial values of results matrix to zero to be sure */
+
     clearvec(rC,N*N);
     clearvec(iC,N*N);
 
-    int Npsj, Npsk;
-    int cj, ck;
-    Npsj=0;
-    Npsk=0;
+    int Npsi=0, Npsj=0, Npsk=0;
 
-    float *psj, *psk;
-    psj=(float *)calloc(N,sizeof(float));
-    psk=(float *)calloc(N,sizeof(float));
+    int *psi = (int*)malloc(N*sizeof(int));
+    int *psj = (int*)malloc(N*sizeof(int));
+    int *psk = (int*)malloc(N*sizeof(int));
 
     for (i=0;i<N;i++){
-        if (psites[i]==sj){
-            psj[Npsj]=i;
-            Npsj++;
-        }
-        if (psites[i]==sk){
-            psk[Npsk]=i;
-            Npsk++;
-        }
+        if (psites[i]==si) psi[Npsi++] = i;
+        if (psites[i]==sj) psj[Npsj++] = i;
+        if (psites[i]==sk) psk[Npsk++] = i;
     }
 
-#pragma omp parallel for
-    for (i=0;i<N;i++){
-        if (psites[i]==si){
-            for (cj=0;cj<Npsj;cj++){
-                j=psj[cj];
-                for (ck=0;ck<Npsk;ck++){
-                    k=psk[ck];
-                    rC[i*N+j]+=rA[i*N+k]*rB[k*N+j]-iA[i*N+k]*iB[k*N+j];
-                    iC[i*N+j]+=rA[i*N+k]*iB[k*N+j]+iA[i*N+k]*rB[k*N+j];
-                }
-            }
-        }
-    }
+    /* Create submatrices based in the segment input */
+    float *Ar = (float*)malloc(Npsi*Npsk*sizeof(float));
+    float *Ai = (float*)malloc(Npsi*Npsk*sizeof(float));
+    float *Br = (float*)malloc(Npsk*Npsj*sizeof(float));
+    float *Bi = (float*)malloc(Npsk*Npsj*sizeof(float));
 
-    /*
-    for (i=0;i<N;i++){
-        if (psites[i]==si){
-            for (j=0;j<N;j++){
-                if (psites[j]==sj){
-                    for (k=0;k<N;k++){
-                        if (psites[k]==sk){
-                            rC[i*N+j]+=rA[i*N+k]*rB[k*N+j]-iA[i*N+k]*iB[k*N+j];
-                            iC[i*N+j]+=rA[i*N+k]*iB[k*N+j]+iA[i*N+k]*rB[k*N+j];
-                        } 
-                    } 
-                }
-            }
+    /* Do the segment projection */
+    for (i=0;i<Npsi;i++)
+        for (k=0;k<Npsk;k++){
+            Ar[i*Npsk+k] = rA[psi[i]*N + psk[k]];
+            Ai[i*Npsk+k] = iA[psi[i]*N + psk[k]];
         }
-    }
-    */
-    free(psj);
-    free(psk);
-    return;
-} 
+
+    for (k=0;k<Npsk;k++)
+        for (j=0;j<Npsj;j++){
+            Br[k*Npsj+j] = rB[psk[k]*N + psj[j]];
+            Bi[k*Npsj+j] = iB[psk[k]*N + psj[j]];
+        }
+
+    /* Allocate result blocks */
+    float *Cr = (float*)calloc(Npsi*Npsj,sizeof(float));
+    float *Ci = (float*)calloc(Npsi*Npsj,sizeof(float));
+
+    /* Complex GEMM via 4 real GEMMs */
+
+    // Cr += Ar*Br (with Cr presumed initialised at zero)
+    cblas_sgemm(CblasRowMajor,CblasNoTrans,CblasNoTrans,
+        Npsi,Npsj,Npsk,1.0f,Ar,Npsk,Br,Npsj,1.0f,Cr,Npsj);
+
+    // Cr -= Ai*Bi
+    cblas_sgemm(CblasRowMajor,CblasNoTrans,CblasNoTrans,
+        Npsi,Npsj,Npsk,-1.0f,Ai,Npsk,Bi,Npsj,1.0f,Cr,Npsj);
+
+    // Ci += Ar*Bi
+    cblas_sgemm(CblasRowMajor,CblasNoTrans,CblasNoTrans,
+        Npsi,Npsj,Npsk,1.0f,Ar,Npsk,Bi,Npsj,1.0f,Ci,Npsj);
+
+    // Ci += Ai*Br
+    cblas_sgemm(CblasRowMajor,CblasNoTrans,CblasNoTrans,
+        Npsi,Npsj,Npsk,1.0f,Ai,Npsk,Br,Npsj,1.0f,Ci,Npsj);
+
+    /* place submatrix back in original N*N matrix */
+    for (i=0;i<Npsi;i++)
+        for (j=0;j<Npsj;j++){
+            rC[psi[i]*N + psj[j]] = Cr[i*Npsj+j];
+            iC[psi[i]*N + psj[j]] = Ci[i*Npsj+j];
+        }
+
+    free(psi); free(psj); free(psk);
+    free(Ar); free(Ai); free(Br); free(Bi);
+    free(Cr); free(Ci);
+}
 
 /* Find the trace of the matrix */
 float trace_rate(float *matrix,int N){

--- a/src/mcfret.c
+++ b/src/mcfret.c
@@ -1224,6 +1224,44 @@ void mcfret_energy(float *E,t_non *non,int segments, float *ave_vecr,float *ener
     return;
 }
 
+void transform_back_to_site(int N,
+                           const float *A_float,
+                           const double *c2,
+                           double *matrix)
+{
+    int i, j;
+    // Perform: matrix_site = A^T * matrix_eigen * A, because A is H, where H is the transpose of the eigenvector matrix.
+    // Convert A -> double (BLAS uses double here)
+    double *A = (double*) malloc(N*N*sizeof(double));
+    double *temp = (double*) calloc(N*N,sizeof(double));
+
+    for (i = 0; i < N*N; i++)
+        A[i] = (double) A_float[i];
+
+    // temp = A * diag(c2)
+    // scale each row j by c2[j]
+    for (j = 0; j < N; j++) {
+        for (i = 0; i < N; i++) {
+            temp[i * N + j] = A[i * N + j] * c2[j];
+        }
+    }
+
+    // matrix = A * temp 
+    cblas_dgemm(
+        CblasColMajor,
+        CblasTrans,    
+        CblasNoTrans,
+        N, N, N,
+        1.0,
+        A, N,
+        temp, N,
+        0.0,
+        matrix, N);
+
+    free(A);
+    free(temp);
+}
+
 /* This function will create a density matrix where every term is weighted with a Boltzmann weight */
 void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int segments, float *partition_functions){
     int index,N;
@@ -1256,8 +1294,8 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int s
         }
     }
     /* Find eigenvalues and eigenvectors */
-    diagonalizeLPD(H,e,N); 
- 
+    diagonalizeLPD(H,e,N);
+
     /* Exponentiate [U=exp(-H/kBT)] */
     for (a=0;a<N;a++){
         if (non->temperature==0){
@@ -1273,20 +1311,7 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int s
     }
 
     /* Transform back to site basis */ 
-    for (a=0;a<N;a++){
-        for (b=0;b<N;b++){
-            cnr[b+a*N]+=((double) H[b+a*N])*c2[b];
-        }
-    }  
-
-// #pragma omp parallel for
-    for (a=0;a<N;a++){
-        for (b=0;b<N;b++){
-            for (c=0;c<N;c++){
-                matrix[a+c*N]+=H[b+a*N]*cnr[b+c*N];
-            }
-        }
-    }
+    transform_back_to_site(N, H, c2, matrix);
   
     /* Find the partition function for each segment */
     for (a=0;a<N;a++){

--- a/src/mcfret.c
+++ b/src/mcfret.c
@@ -1263,79 +1263,206 @@ void transform_back_to_site(int N,
 }
 
 /* This function will create a density matrix where every term is weighted with a Boltzmann weight */
-void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int segments, float *partition_functions){
+void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N_segments, float *partition_functions){
     int index,N;
     float *H,*e;
     double *c2;
     double *cnr;
     double *matrix;
 
-    N=non->singles;
-    H=(float *)calloc(N*N,sizeof(float));
-    e=(float *)calloc(N,sizeof(float));
-    c2=(double *)calloc(N,sizeof(double));
-    cnr=(double *)calloc(N*N,sizeof(double));
-    matrix=(double *)calloc(N*N,sizeof(double));
+    FILE *log;
 
-    int a,b,c,s;
+    N=non->singles;
+
+    int a,b,c;
+    int si;
+    int N_site_si;
+    int *H_indices_si;
+    H_indices_si = (int *)calloc(N,sizeof(int));
+    int seg_ref_idx = 0;
+
     double kBT=(double) non->temperature*k_B; /* Kelvin to cm-1 */
-    double *Q,iQ;
  
     clearvec(density_matrix,N*N);
 
-    Q=(double *)calloc(segments,sizeof(double));  
+    double Boltzmann;
+    double segment_partition_func = 0;
 
-    /* Build Hamiltonian */
-    for (a=0;a<N;a++){
-        H[a+N*a]=Hamiltonian_i[a+N*a-(a*(a+1))/2]; /* Diagonal */
-        for (b=a+1;b<N;b++){
-            H[a+N*b]=Hamiltonian_i[b+N*a-(a*(a+1))/2];
-            H[b+N*a]=Hamiltonian_i[b+N*a-(a*(a+1))/2];
+    double reference_energy;
+    reference_energy = non->max1; // Simply use the first value of the maximum indicated frequencies as reference energy
+
+    for (si=0;si<N_segments;si++){
+        float *Hamiltonian_segment_triu;
+        N_site_si = find_H_indices_segment(non->psites, H_indices_si, si, non);
+        Hamiltonian_segment_triu = (float *)calloc((N_site_si+1)*N_site_si/2,sizeof(float));
+        H=(float *)calloc(N_site_si*N_site_si,sizeof(float));
+        e=(float *)calloc(N_site_si,sizeof(float));
+        c2=(double *)calloc(N_site_si,sizeof(double));
+        cnr=(double *)calloc(N_site_si*N_site_si,sizeof(double));
+        matrix=(double *)calloc(N_site_si*N_site_si,sizeof(double));
+
+        // clear the partition function for each segment
+        segment_partition_func = 0;
+
+
+        // isolate the segment i with projection routine to obtain smaller matrix
+        isolate_segment_Hamiltonian_triu(Hamiltonian_i, Hamiltonian_segment_triu, H_indices_si, N_site_si, non);
+
+        /* Build segment Hamiltonian */
+        for (a=0;a<N_site_si;a++){
+            H[a+N_site_si*a]=Hamiltonian_segment_triu[a+N_site_si*a-(a*(a+1))/2]; /* Diagonal */
+            for (b=a+1;b<N_site_si;b++){
+                H[a+N_site_si*b]=Hamiltonian_segment_triu[b+N_site_si*a-(a*(a+1))/2];
+                H[b+N_site_si*a]=Hamiltonian_segment_triu[b+N_site_si*a-(a*(a+1))/2];
+
+            }
         }
-    }
-    /* Find eigenvalues and eigenvectors */
-    diagonalizeLPD(H,e,N);
+        /* Find eigenvalues and eigenvectors */
+        diagonalizeLPD(H,e,N_site_si);
 
-    /* Exponentiate [U=exp(-H/kBT)] */
-    for (a=0;a<N;a++){
-        if (non->temperature==0){
-            printf("Temperature is 0, the equilirbium density matrix will be nan,we suggestion to use a low non-zero temperature instead");
-            exit(0);
+        log=fopen("NISE.log","a");
+        fprintf(log,"Boltzmann factors for segment %d: ", si);
+        /* Exponentiate [U=exp(-H/kBT)] */
+        for (a=0;a<N_site_si;a++){
+            if (non->temperature==0){
+                printf("Temperature is 0, the equilirbium density matrix will be nan,we suggestion to use a low non-zero temperature instead");
+                exit(0);
+            }
+
+            Boltzmann = exp(-((double) (e[a]-reference_energy))/kBT);
+            /* Apply strict high temperature limit when T>100000 */
+            if (non->temperature>100000){
+                Boltzmann=1.0;
+            }
+            c2[a] = Boltzmann;
+            segment_partition_func += Boltzmann;
+            fprintf(log," %e ", Boltzmann);
         }
+        fprintf(log,"\n" );
+        fclose(log);
 
-        c2[a]=exp(-((double) (e[a]-e[N-1]))/kBT);
-        /* Apply strict high temperature limit when T>100000 */
-        if (non->temperature>100000){
-	        c2[a]=1.0;
+        /* Transform back to site basis */ 
+        transform_back_to_site(N_site_si, H, c2, matrix);
+
+        /* Re-normalize and write to overarching density matrix */
+        
+        for (a=0;a<N_site_si;a++){
+            for (b=0;b<N_site_si;b++){
+                density_matrix[H_indices_si[a]+H_indices_si[b]*N]=(float) (matrix[a+b*N_site_si]/segment_partition_func);
+            }
         }
-    }
+    
+        /* Update the ensemble average partition function for each segment*/
+        partition_functions[si] += (float) segment_partition_func;
+        printf("Partition function for segment %d =  %e \n",si,segment_partition_func);
+        log=fopen("NISE.log","a");
+        fprintf(log,"Partition function for segment %d =  %e \n",si,segment_partition_func);
+        fclose(log);
+    
+    
+        free(Hamiltonian_segment_triu);
+        free(H);
+        free(c2);
+        free(e);
+        free(cnr);
+    } //close the segment loop
+    free(H_indices_si);
 
-    /* Transform back to site basis */ 
-    transform_back_to_site(N, H, c2, matrix);
-  
-    /* Find the partition function for each segment */
-    for (a=0;a<N;a++){
-        Q[non->psites[a]]+=matrix[a+a*N];
-    }
-    /* Re-normalize */
-    for (a=0;a<N;a++){
-        for (b=0;b<N;b++){
-    	    density_matrix[a+b*N]=(float) (matrix[a+b*N]/Q[non->psites[a]]);
-        }
-    }      
 
-    /* Update the ensemble average partition function for each segment*/
-    for(s=0;s<segments;s++){
-       partition_functions[s] += Q[s];
-    }
-
-    free(H);
-    free(c2);
-    free(e);
-    free(cnr);
-    free(Q);
     return;
 }
+
+// old: likely wrong, as the inter-segment density elements are nullified, however, the inter-segment couplings in the hamiltonian should be nullified instead.
+// /* This function will create a density matrix where every term is weighted with a Boltzmann weight */
+// void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int segments, float *partition_functions){
+//     int index,N;
+//     float *H,*e;
+//     double *c2;
+//     double *cnr;
+//     double *matrix;
+
+//     FILE *log;
+
+//     N=non->singles;
+//     H=(float *)calloc(N*N,sizeof(float));
+//     e=(float *)calloc(N,sizeof(float));
+//     c2=(double *)calloc(N,sizeof(double));
+//     cnr=(double *)calloc(N*N,sizeof(double));
+//     matrix=(double *)calloc(N*N,sizeof(double));
+
+//     int a,b,c,s;
+//     double kBT=(double) non->temperature*k_B; /* Kelvin to cm-1 */
+//     double *Q,iQ;
+ 
+//     clearvec(density_matrix,N*N);
+
+//     Q=(double *)calloc(segments,sizeof(double));  
+
+//     /* Build Hamiltonian */
+//     for (a=0;a<N;a++){
+//         H[a+N*a]=Hamiltonian_i[a+N*a-(a*(a+1))/2]; /* Diagonal */
+//         for (b=a+1;b<N;b++){
+
+//             //only write elements of the Hamiltonian within each segment (nullify the inter-segment couplings)
+//             if (non->psites[a] == non->psites[b]){
+//                 H[a+N*b]=Hamiltonian_i[b+N*a-(a*(a+1))/2];
+//                 H[b+N*a]=Hamiltonian_i[b+N*a-(a*(a+1))/2];
+//             }
+//         }
+//     }
+//     /* Find eigenvalues and eigenvectors */
+//     diagonalizeLPD(H,e,N);
+
+//     log=fopen("NISE.log","a");
+//     fprintf(log,"Boltzmann factors: " );
+//     /* Exponentiate [U=exp(-H/kBT)] */
+//     for (a=0;a<N;a++){
+//         if (non->temperature==0){
+//             printf("Temperature is 0, the equilirbium density matrix will be nan,we suggestion to use a low non-zero temperature instead");
+//             exit(0);
+//         }
+
+//         c2[a]=exp(-((double) (e[a]-e[N-1]))/kBT);
+
+//         fprintf(log," %e ", c2[a]);
+//         /* Apply strict high temperature limit when T>100000 */
+//         if (non->temperature>100000){
+// 	        c2[a]=1.0;
+//         }
+//     }
+//     fprintf(log,"\n" );
+//     fclose(log);
+
+//     /* Transform back to site basis */ 
+//     transform_back_to_site(N, H, c2, matrix);
+  
+//     /* Find the partition function for each segment */
+//     for (a=0;a<N;a++){
+//         Q[non->psites[a]]+=matrix[a+a*N];
+//     }
+//     /* Re-normalize */
+//     for (a=0;a<N;a++){
+//         for (b=0;b<N;b++){
+//     	    density_matrix[a+b*N]=(float) (matrix[a+b*N]/Q[non->psites[a]]);
+//         }
+//     }      
+
+//     /* Update the ensemble average partition function for each segment*/
+//     for(s=0;s<segments;s++){
+//         partition_functions[s] += Q[s];
+//         printf("Partition function for segment %d =  %e \n",s,Q[s]);
+//         log=fopen("NISE.log","a");
+//         fprintf(log,"Partition function for segment %d =  %e \n",s,Q[s]);
+//         fclose(log);
+//     }
+
+//     free(H);
+//     free(c2);
+//     free(e);
+//     free(cnr);
+//     free(Q);
+//     return;
+// }
 
 void average_density_matrix(float *ave_den_mat,t_non *non){
 /* Define variables and arrays */

--- a/src/mcfret.c
+++ b/src/mcfret.c
@@ -1288,7 +1288,7 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
     double segment_partition_func = 0;
 
     double reference_energy;
-    reference_energy = non->max1; // Simply use the first value of the maximum indicated frequencies as reference energy
+    reference_energy = non->min1; // Simply use the first value of the maximum indicated frequencies as reference energy
 
     for (si=0;si<N_segments;si++){
         float *Hamiltonian_segment_triu;
@@ -1317,9 +1317,10 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
         }
         /* Find eigenvalues and eigenvectors */
         diagonalizeLPD(H,e,N_site_si);
-
-        log=fopen("NISE.log","a");
-        fprintf(log,"Boltzmann factors for segment %d: ", si);
+        if (non->printLevel>0){
+            log=fopen("NISE.log","a");
+            fprintf(log,"Boltzmann factors for segment %d: ", si);
+        }
         /* Exponentiate [U=exp(-H/kBT)] */
         for (a=0;a<N_site_si;a++){
             if (non->temperature==0){
@@ -1334,10 +1335,14 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
             }
             c2[a] = Boltzmann;
             segment_partition_func += Boltzmann;
-            fprintf(log," %e ", Boltzmann);
+            if (non->printLevel>0){
+                fprintf(log," %e ", Boltzmann);
+            }
         }
-        fprintf(log,"\n" );
-        fclose(log);
+        if (non->printLevel>0){
+            fprintf(log,"\n" );
+            fclose(log);
+        }
 
         /* Transform back to site basis */ 
         transform_back_to_site(N_site_si, H, c2, matrix);
@@ -1352,10 +1357,12 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
     
         /* Update the ensemble average partition function for each segment*/
         partition_functions[si] += (float) segment_partition_func;
-        printf("Partition function for segment %d =  %e \n",si,segment_partition_func);
-        log=fopen("NISE.log","a");
-        fprintf(log,"Partition function for segment %d =  %e \n",si,segment_partition_func);
-        fclose(log);
+        if (non->printLevel>0){
+            printf("Partition function for segment %d =  %e \n",si,segment_partition_func);
+            log=fopen("NISE.log","a");
+            fprintf(log,"Partition function for segment %d =  %e \n",si,segment_partition_func);
+            fclose(log);
+        }
     
     
         free(Hamiltonian_segment_triu);
@@ -1514,16 +1521,11 @@ void average_density_matrix(float *ave_den_mat,t_non *non){
           ave_den_mat[ele] +=vecr[ele]; 
       }
     }
-    /* Zero the coupling between different segments for the averaged density *
-     * matrix and normalize */
+    /* Normalise the average density matrix */
     i_samples=1.0/my_samples;
     for (a=0;a<non->singles;a++){
         for (b=0;b<non->singles;b++){
 	    ave_den_mat[non->singles*b+a]*=i_samples;
-            if (non->psites[a] != non->psites[b]){
-               ave_den_mat[non->singles*a+b]=0.0;
-               /* ave_den_mat[non->singles*b+a]=0.0; */
-            } 
         }
     }
 

--- a/src/mcfret.c
+++ b/src/mcfret.c
@@ -1230,7 +1230,7 @@ void transform_back_to_site(int N,
                            double *matrix)
 {
     int i, j;
-    // Perform: matrix_site = A^T * matrix_eigen * A, because A is H, where H is the transpose of the eigenvector matrix.
+    // Perform: matrix_site = H * matrix_eigen * H.T
     // Convert A -> double (BLAS uses double here)
     double *A = (double*) malloc(N*N*sizeof(double));
     double *temp = (double*) calloc(N*N,sizeof(double));
@@ -1239,22 +1239,22 @@ void transform_back_to_site(int N,
         A[i] = (double) A_float[i];
 
     // temp = A * diag(c2)
-    // scale each row j by c2[j]
-    for (j = 0; j < N; j++) {
-        for (i = 0; i < N; i++) {
+    // scale each column j by c2[i]
+    for (i = 0; i < N; i++) {
+        for (j = 0; j < N; j++) {
             temp[i * N + j] = A[i * N + j] * c2[j];
         }
     }
 
-    // matrix = A * temp 
+    // matrix =  temp * A^T =  (A * D) * A^T 
     cblas_dgemm(
-        CblasColMajor,
-        CblasTrans,    
-        CblasNoTrans,
+        CblasRowMajor,
+        CblasNoTrans,    
+        CblasTrans,
         N, N, N,
         1.0,
-        A, N,
         temp, N,
+        A, N,
         0.0,
         matrix, N);
 
@@ -1267,7 +1267,6 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
     int index,N;
     float *H,*e;
     double *c2;
-    double *cnr;
     double *matrix;
 
     FILE *log;
@@ -1298,7 +1297,6 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
         H=(float *)calloc(N_site_si*N_site_si,sizeof(float));
         e=(float *)calloc(N_site_si,sizeof(float));
         c2=(double *)calloc(N_site_si,sizeof(double));
-        cnr=(double *)calloc(N_site_si*N_site_si,sizeof(double));
         matrix=(double *)calloc(N_site_si*N_site_si,sizeof(double));
 
         // clear the partition function for each segment
@@ -1364,7 +1362,7 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
         free(H);
         free(c2);
         free(e);
-        free(cnr);
+        free(matrix);
     } //close the segment loop
     free(H_indices_si);
 

--- a/src/mcfret.c
+++ b/src/mcfret.c
@@ -1288,7 +1288,7 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
     double segment_partition_func = 0;
 
     double reference_energy;
-    reference_energy = non->min1; // Simply use the first value of the maximum indicated frequencies as reference energy
+    reference_energy = non->min1; // Simply use the first value of the minimum indicated frequencies as reference energy
 
     for (si=0;si<N_segments;si++){
         float *Hamiltonian_segment_triu;
@@ -1317,14 +1317,14 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
         }
         /* Find eigenvalues and eigenvectors */
         diagonalizeLPD(H,e,N_site_si);
-        if (non->printLevel>0){
+        if (non->printLevel>1){
             log=fopen("NISE.log","a");
             fprintf(log,"Boltzmann factors for segment %d: ", si);
         }
         /* Exponentiate [U=exp(-H/kBT)] */
         for (a=0;a<N_site_si;a++){
             if (non->temperature==0){
-                printf("Temperature is 0, the equilirbium density matrix will be nan,we suggestion to use a low non-zero temperature instead");
+                printf("Temperature is 0, the equilibrium density matrix will be nan, we suggest using a low non-zero temperature instead");
                 exit(0);
             }
 
@@ -1335,7 +1335,7 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
             }
             c2[a] = Boltzmann;
             segment_partition_func += Boltzmann;
-            if (non->printLevel>0){
+            if (non->printLevel>1){
                 fprintf(log," %e ", Boltzmann);
             }
         }
@@ -1359,9 +1359,9 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
         partition_functions[si] += (float) segment_partition_func;
         if (non->printLevel>0){
             printf("Partition function for segment %d =  %e \n",si,segment_partition_func);
-            log=fopen("NISE.log","a");
-            fprintf(log,"Partition function for segment %d =  %e \n",si,segment_partition_func);
-            fclose(log);
+            // log=fopen("NISE.log","a");
+            // fprintf(log,"Partition function for segment %d =  %e \n",si,segment_partition_func);
+            // fclose(log);
         }
     
     
@@ -1376,98 +1376,6 @@ void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int N
 
     return;
 }
-
-// old: likely wrong, as the inter-segment density elements are nullified, however, the inter-segment couplings in the hamiltonian should be nullified instead.
-// /* This function will create a density matrix where every term is weighted with a Boltzmann weight */
-// void density_matrix(float *density_matrix, float *Hamiltonian_i,t_non *non,int segments, float *partition_functions){
-//     int index,N;
-//     float *H,*e;
-//     double *c2;
-//     double *cnr;
-//     double *matrix;
-
-//     FILE *log;
-
-//     N=non->singles;
-//     H=(float *)calloc(N*N,sizeof(float));
-//     e=(float *)calloc(N,sizeof(float));
-//     c2=(double *)calloc(N,sizeof(double));
-//     cnr=(double *)calloc(N*N,sizeof(double));
-//     matrix=(double *)calloc(N*N,sizeof(double));
-
-//     int a,b,c,s;
-//     double kBT=(double) non->temperature*k_B; /* Kelvin to cm-1 */
-//     double *Q,iQ;
- 
-//     clearvec(density_matrix,N*N);
-
-//     Q=(double *)calloc(segments,sizeof(double));  
-
-//     /* Build Hamiltonian */
-//     for (a=0;a<N;a++){
-//         H[a+N*a]=Hamiltonian_i[a+N*a-(a*(a+1))/2]; /* Diagonal */
-//         for (b=a+1;b<N;b++){
-
-//             //only write elements of the Hamiltonian within each segment (nullify the inter-segment couplings)
-//             if (non->psites[a] == non->psites[b]){
-//                 H[a+N*b]=Hamiltonian_i[b+N*a-(a*(a+1))/2];
-//                 H[b+N*a]=Hamiltonian_i[b+N*a-(a*(a+1))/2];
-//             }
-//         }
-//     }
-//     /* Find eigenvalues and eigenvectors */
-//     diagonalizeLPD(H,e,N);
-
-//     log=fopen("NISE.log","a");
-//     fprintf(log,"Boltzmann factors: " );
-//     /* Exponentiate [U=exp(-H/kBT)] */
-//     for (a=0;a<N;a++){
-//         if (non->temperature==0){
-//             printf("Temperature is 0, the equilirbium density matrix will be nan,we suggestion to use a low non-zero temperature instead");
-//             exit(0);
-//         }
-
-//         c2[a]=exp(-((double) (e[a]-e[N-1]))/kBT);
-
-//         fprintf(log," %e ", c2[a]);
-//         /* Apply strict high temperature limit when T>100000 */
-//         if (non->temperature>100000){
-// 	        c2[a]=1.0;
-//         }
-//     }
-//     fprintf(log,"\n" );
-//     fclose(log);
-
-//     /* Transform back to site basis */ 
-//     transform_back_to_site(N, H, c2, matrix);
-  
-//     /* Find the partition function for each segment */
-//     for (a=0;a<N;a++){
-//         Q[non->psites[a]]+=matrix[a+a*N];
-//     }
-//     /* Re-normalize */
-//     for (a=0;a<N;a++){
-//         for (b=0;b<N;b++){
-//     	    density_matrix[a+b*N]=(float) (matrix[a+b*N]/Q[non->psites[a]]);
-//         }
-//     }      
-
-//     /* Update the ensemble average partition function for each segment*/
-//     for(s=0;s<segments;s++){
-//         partition_functions[s] += Q[s];
-//         printf("Partition function for segment %d =  %e \n",s,Q[s]);
-//         log=fopen("NISE.log","a");
-//         fprintf(log,"Partition function for segment %d =  %e \n",s,Q[s]);
-//         fclose(log);
-//     }
-
-//     free(H);
-//     free(c2);
-//     free(e);
-//     free(cnr);
-//     free(Q);
-//     return;
-// }
 
 void average_density_matrix(float *ave_den_mat,t_non *non){
 /* Define variables and arrays */

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -1300,66 +1300,88 @@ int time_evolution_mat(t_non* non, float* Hamiltonian_i, float* Ur, float* Ui, i
 }
 
 /* Create snapshot time-evolution operator for a single segment */
-void time_evolution_mat_non_sparse(t_non* non, float* Hamiltonian_i, float* Ur, float* Ui, int Ni) {
+void time_evolution_mat_non_sparse(t_non* non,
+                                   float* Hamiltonian_i,
+                                   float* Ur,
+                                   float* Ui,
+                                   int Ni)
+{
     int N = Ni;
     float f = non->deltat * icm2ifs * (float)twoPi;
     size_t sz = (size_t)N * N;
 
-    float *H    = (float *)calloc(sz, sizeof(float));
-    float *e    = (float *)calloc(N, sizeof(float));
+    float *H  = (float *)calloc(sz, sizeof(float)); // temp (transpose of eigenvectors)
+    float *V  = (float *)calloc(sz, sizeof(float)); // eigenvectors as columns
+    float *e  = (float *)calloc(N, sizeof(float));
     float *re_U = (float *)calloc(N, sizeof(float));
     float *im_U = (float *)calloc(N, sizeof(float));
-    float *cnr  = (float *)calloc(sz, sizeof(float));
-    float *cni  = (float *)calloc(sz, sizeof(float));
+    float *tmp_r = (float *)calloc(sz, sizeof(float));
+    float *tmp_i = (float *)calloc(sz, sizeof(float));
 
-    // BLAS sgemm with beta=0.0 overwrites Ur/Ui
-    // no need to memset Ui or Ur
+    float alpha = 1.0f;
+    float beta  = 0.0f;
 
-    /* 1. Build Hamiltonian */
+    /* 1. Build Hamiltonian (column-major layout) */
     for (int a = 0; a < N; a++) {
-        int tri_offset = (a * (a + 1)) / 2;
-        H[a + N * a] = Hamiltonian_i[a + N * a - tri_offset];
+        int triangle_offset = (a * (a + 1)) / 2;
+        H[a + a*N] = Hamiltonian_i[a + N*a - tri_offset];
         for (int b = a + 1; b < N; b++) {
-            float val = Hamiltonian_i[b + N * a - tri_offset];
-            H[a + N * b] = val;
-            H[b + N * a] = val;
+            float val = Hamiltonian_i[b + N*a - triangle_offset];
+            H[a + b*N] = val;
+            H[b + a*N] = val;
         }
     }
 
-    /* 2. Diagonalize */
+    /* 2. Diagonalize: H → eigenvectors in ROWS */
     diagonalizeLPD(H, e, N);
 
-    /* 3. Exponentiate */
+    /* 3. Transpose to get V with eigenvectors as COLUMNS */
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            V[i + j*N] = H[j + i*N];
+        }
+    }
+
+    /* 4. Exponent of eigenvalues */
     for (int a = 0; a < N; a++) {
         re_U[a] = cosf(e[a] * f);
         im_U[a] = -sinf(e[a] * f);
     }
 
-    /* 4. Transform back to site basis. */
-    for (int a = 0; a < N; a++) {
-        for (int b = 0; b < N; b++) {
-            cnr[b + a * N] = H[b + a * N] * re_U[b];
-            cni[b + a * N] = H[b + a * N] * im_U[b];
+    /* 5. tmp = V * D  (scale columns of V) */
+    for (int j = 0; j < N; j++) {
+        float sr = re_U[j];
+        float si = im_U[j];
+        for (int i = 0; i < N; i++) {
+            tmp_r[i + j*N] = V[i + j*N] * sr;
+            tmp_i[i + j*N] = V[i + j*N] * si;
         }
     }
 
-    // Ur(a,c) = sum over b of [ H(b,a) * cnr(b,c) ]
-    // This is C = A^T * B
-    float alpha = 1.0f;
-    float beta  = 0.0f; // overwrite output matrices
+    /* 6. Ur = tmp_r * V^T */
+    cblas_sgemm(CblasColMajor,
+                CblasNoTrans, CblasTrans,
+                N, N, N,
+                alpha,
+                tmp_r, N,
+                V, N,
+                beta,
+                Ur, N);
 
-    // Ur = H^T * cnr
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, 
-                N, N, N, alpha, H, N, cnr, N, beta, Ur, N);
+    /* 7. Ui = tmp_i * V^T */
+    cblas_sgemm(CblasColMajor,
+                CblasNoTrans, CblasTrans,
+                N, N, N,
+                alpha,
+                tmp_i, N,
+                V, N,
+                beta,
+                Ui, N);
 
-    // Ui = H^T * cni
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, 
-                N, N, N, alpha, H, N, cni, N, beta, Ui, N);
-
-    // Cleanup
-    free(H); free(e); free(re_U); free(im_U); free(cnr); free(cni);
+    free(H); free(V); free(e);
+    free(re_U); free(im_U);
+    free(tmp_r); free(tmp_i);
 }
-
 
 /* This function propagates the doubles for three level systems with the */
 /* sparse time-evolution operator algorithm. The singles time evolution */

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -1324,7 +1324,7 @@ void time_evolution_mat_non_sparse(t_non* non,
     /* 1. Build Hamiltonian (column-major layout) */
     for (int a = 0; a < N; a++) {
         int triangle_offset = (a * (a + 1)) / 2;
-        H[a + a*N] = Hamiltonian_i[a + N*a - tri_offset];
+        H[a + a*N] = Hamiltonian_i[a + N*a - triangle_offset];
         for (int b = a + 1; b < N; b++) {
             float val = Hamiltonian_i[b + N*a - triangle_offset];
             H[a + b*N] = val;

--- a/src/propagate.c
+++ b/src/propagate.c
@@ -1310,8 +1310,7 @@ void time_evolution_mat_non_sparse(t_non* non,
     float f = non->deltat * icm2ifs * (float)twoPi;
     size_t sz = (size_t)N * N;
 
-    float *H  = (float *)calloc(sz, sizeof(float)); // temp (transpose of eigenvectors)
-    float *V  = (float *)calloc(sz, sizeof(float)); // eigenvectors as columns
+    float *H  = (float *)calloc(sz, sizeof(float)); // eigenvectors as rows (from diagonalizeLPD)
     float *e  = (float *)calloc(N, sizeof(float));
     float *re_U = (float *)calloc(N, sizeof(float));
     float *im_U = (float *)calloc(N, sizeof(float));
@@ -1321,64 +1320,60 @@ void time_evolution_mat_non_sparse(t_non* non,
     float alpha = 1.0f;
     float beta  = 0.0f;
 
-    /* 1. Build Hamiltonian (column-major layout) */
+    /* 1. Build Hamiltonian (row-major layout) */
+    /* Build Hamiltonian */
     for (int a = 0; a < N; a++) {
-        int triangle_offset = (a * (a + 1)) / 2;
-        H[a + a*N] = Hamiltonian_i[a + N*a - triangle_offset];
+        H[a + N * a] = Hamiltonian_i[a + N * a - (a * (a + 1)) / 2]; // Diagonal
         for (int b = a + 1; b < N; b++) {
-            float val = Hamiltonian_i[b + N*a - triangle_offset];
-            H[a + b*N] = val;
-            H[b + a*N] = val;
+            H[a + N * b] = Hamiltonian_i[b + N * a - (a * (a + 1)) / 2];
+            H[b + N * a] = Hamiltonian_i[b + N * a - (a * (a + 1)) / 2];
         }
-    }
+    } 
 
-    /* 2. Diagonalize: H → eigenvectors in ROWS */
+    /* 2. Diagonalize: H → eigenvectors in COLUMNS, row major layout */
     diagonalizeLPD(H, e, N);
 
-    /* 3. Transpose to get V with eigenvectors as COLUMNS */
-    for (int i = 0; i < N; i++) {
-        for (int j = 0; j < N; j++) {
-            V[i + j*N] = H[j + i*N];
-        }
-    }
-
-    /* 4. Exponent of eigenvalues */
+    /* 3. Exponent of eigenvalues */
     for (int a = 0; a < N; a++) {
         re_U[a] = cosf(e[a] * f);
         im_U[a] = -sinf(e[a] * f);
     }
 
-    /* 5. tmp = V * D  (scale columns of V) */
-    for (int j = 0; j < N; j++) {
-        float sr = re_U[j];
-        float si = im_U[j];
-        for (int i = 0; i < N; i++) {
-            tmp_r[i + j*N] = V[i + j*N] * sr;
-            tmp_i[i + j*N] = V[i + j*N] * si;
+    /* 4. tmp_r = D * H (scale columns of H by real part of exponentials) */
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            tmp_r[i*N + j] = H[i*N + j] * re_U[j];
         }
     }
 
-    /* 6. Ur = tmp_r * V^T */
-    cblas_sgemm(CblasColMajor,
+    /* 5. tmp_i = D * H (scale columns of H by imaginary part of exponentials) */
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            tmp_i[i*N + j] = H[i*N + j] *  im_U[j];
+        }
+    }
+
+    /* 6. Ur =  tmp_r @ H^T (row-major) */
+    cblas_sgemm(CblasRowMajor,
                 CblasNoTrans, CblasTrans,
                 N, N, N,
                 alpha,
                 tmp_r, N,
-                V, N,
+                H, N,
                 beta,
                 Ur, N);
 
-    /* 7. Ui = tmp_i * V^T */
-    cblas_sgemm(CblasColMajor,
+    /* 7. Ui =  tmp_i @ H^T  (row-major) */
+    cblas_sgemm(CblasRowMajor,
                 CblasNoTrans, CblasTrans,
                 N, N, N,
                 alpha,
                 tmp_i, N,
-                V, N,
+                H, N,
                 beta,
                 Ui, N);
 
-    free(H); free(V); free(e);
+    free(H); free(e);
     free(re_U); free(im_U);
     free(tmp_r); free(tmp_i);
 }


### PR DESCRIPTION
Also includes changes to use of BLAS in propagation.
Using this branch may result in different rates, as the density matrix is computed differently.
The partition functions can be printed in the terminal (and in NISE.log) using a PrintLevel higher than zero. For statistical analysis, the individual Boltzmann factors are also provided in NISE.log